### PR TITLE
fix: 홈 중앙정렬 및 로고 드래그 방지

### DIFF
--- a/next-converter/src/app/globals.css
+++ b/next-converter/src/app/globals.css
@@ -82,6 +82,7 @@ a {
 .header-content h1 {
   margin: 0;
   font-size: 2.2em;
+  user-select: none;
 }
 
 .user-info {
@@ -898,4 +899,14 @@ button[type='submit']:disabled {
 
 .animation-delay-4000 {
   animation-delay: 4s;
+}
+
+@media (min-width: 1024px) {
+  .container {
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/next-converter/src/app/page.tsx
+++ b/next-converter/src/app/page.tsx
@@ -653,7 +653,7 @@ export default function Home() {
             alt="QuokkaConvert"
             style={{ width: 64, height: 64, marginRight: 8 }}
           />
-          <span className="text-2xl font-bold text-gray-900">
+          <span className="text-2xl font-bold text-gray-900 select-none">
             QuokkaConvert
           </span>
         </div>
@@ -685,7 +685,7 @@ export default function Home() {
       {/* 헤더 */}
       <div className="header">
         <div className="header-content">
-          <h1>QuokkaConvert</h1>
+          <h1 className="select-none">QuokkaConvert</h1>
           <div className="user-info">
             <span className="user-email">{session.user?.email}</span>
             <button onClick={() => signOut()} className="logout-btn">


### PR DESCRIPTION
## 요약
- 로그인 전후 로고를 드래그 할 수 없도록 클래스 추가
- 헤더의 `h1` 요소 드래그 방지 및 큰 화면에서 컨테이너 정렬 스타일 추가

## 테스트 결과
- `npm run lint` 실행 완료
- `npm run build` 실패 (폰트 다운로드 문제)
- `npm start` 실패 (프로덕션 빌드 없음)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685e42b69744832a975442e7d0342865