### PR TITLE
Improve auth flow

### DIFF
--- a/next-converter/middleware.ts
+++ b/next-converter/middleware.ts
@@ -1,0 +1,16 @@
+import { auth } from './src/auth';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export async function middleware(request: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    const url = new URL('/', request.url);
+    return NextResponse.redirect(url);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/convert/:path*'],
+};

--- a/next-converter/src/app/convert/page.tsx
+++ b/next-converter/src/app/convert/page.tsx
@@ -1,6 +1,11 @@
-'use client';
 import Converter from '@/components/Converter';
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
 
-export default function ConvertPage() {
+export default async function ConvertPage() {
+  const session = await auth();
+  if (!session) {
+    redirect('/');
+  }
   return <Converter />;
 }

--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -565,7 +565,7 @@ export default function Converter() {
           <h1 className="select-none">QuokkaConvert</h1>
           <div className="user-info">
             <span className="user-email">{session.user?.email}</span>
-            <button onClick={() => signOut()} className="logout-btn">
+            <button onClick={() => signOut({ callbackUrl: '/' })} className="logout-btn">
               로그아웃
             </button>
           </div>


### PR DESCRIPTION
## Summary
- log out to root page
- protect convert page with server auth and middleware

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch fonts)*
- `npm start` *(fails: Could not find a production build)*

------
https://chatgpt.com/codex/tasks/task_e_685e99139b24832a9ce3147ec180b95d