### PR TITLE
Add bottom navigation

### DIFF
--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import { FaHome, FaExchangeAlt, FaUser } from 'react-icons/fa';
+
+export default function BottomNav() {
+  return (
+    <nav className="fixed bottom-0 w-full border-t border-gray-200 bg-white shadow-md">
+      <ul className="flex justify-around py-2">
+        <li>
+          <Link href="/" className="flex flex-col items-center text-gray-700 hover:text-blue-500">
+            <FaHome size={24} />
+            <span className="mt-1 text-xs">홈</span>
+          </Link>
+        </li>
+        <li>
+          <Link href="/convert" className="flex flex-col items-center text-gray-700 hover:text-blue-500">
+            <FaExchangeAlt size={24} />
+            <span className="mt-1 text-xs">변환</span>
+          </Link>
+        </li>
+        <li>
+          <Link href="/account" className="flex flex-col items-center text-gray-700 hover:text-blue-500">
+            <FaUser size={24} />
+            <span className="mt-1 text-xs">계정</span>
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/next-converter/src/lib/pdfUtils.ts
+++ b/next-converter/src/lib/pdfUtils.ts
@@ -22,7 +22,7 @@ export async function mergePdfs(pdfs: Uint8Array[]): Promise<Uint8Array> {
   for (const pdfBytes of pdfs) {
     const pdf = await PDFDocument.load(pdfBytes);
     const pages = await merged.copyPages(pdf, pdf.getPageIndices());
-    pages.forEach((p: any) => merged.addPage(p));
+    pages.forEach((p) => merged.addPage(p));
   }
   const bytes = await merged.save();
   return new Uint8Array(bytes);


### PR DESCRIPTION
## Summary
- add a fixed bottom navigation component
- remove `any` usage in pdf utilities

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom not installed)*
- `npm run build` *(fails: network access for fonts)*
- `npm start` *(fails: no production build)*

------
https://chatgpt.com/codex/tasks/task_e_685eb0ed6f64832a9612e8e11ddda9b5