### PR TITLE
변환 라우팅 분리와 하단 네비 추가

### DIFF
--- a/next-converter/src/app/convert/layout.tsx
+++ b/next-converter/src/app/convert/layout.tsx
@@ -1,0 +1,10 @@
+import BottomNav from '@/components/BottomNav';
+
+export default function ConvertLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen pb-16">
+      {children}
+      <BottomNav />
+    </div>
+  );
+}

--- a/next-converter/src/app/convert/media/page.tsx
+++ b/next-converter/src/app/convert/media/page.tsx
@@ -1,0 +1,11 @@
+import Converter from '@/components/Converter';
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+
+export default async function MediaConvertPage() {
+  const session = await auth();
+  if (!session) {
+    redirect('/');
+  }
+  return <Converter showModeSelector={false} />;
+}

--- a/next-converter/src/app/convert/page.tsx
+++ b/next-converter/src/app/convert/page.tsx
@@ -1,11 +1,6 @@
-import Converter from '@/components/Converter';
-import { auth } from '@/auth';
 import { redirect } from 'next/navigation';
 
-export default async function ConvertPage() {
-  const session = await auth();
-  if (!session) {
-    redirect('/');
-  }
-  return <Converter />;
+export default function ConvertPage() {
+  redirect('/convert/media');
+  return null;
 }

--- a/next-converter/src/app/convert/pdf/page.tsx
+++ b/next-converter/src/app/convert/pdf/page.tsx
@@ -1,0 +1,11 @@
+import PdfConverter from '@/components/PdfConverter';
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+
+export default async function PdfConvertPage() {
+  const session = await auth();
+  if (!session) {
+    redirect('/');
+  }
+  return <PdfConverter />;
+}

--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -1,28 +1,28 @@
 'use client';
 
 import Link from 'next/link';
-import { FaHome, FaExchangeAlt, FaUser } from 'react-icons/fa';
+import { FaPhotoVideo, FaFilePdf } from 'react-icons/fa';
 
 export default function BottomNav() {
   return (
-    <nav className="fixed bottom-0 w-full border-t border-gray-200 bg-white shadow-md">
+    <nav className="fixed bottom-0 left-0 right-0 border-t border-gray-200 bg-white shadow-md">
       <ul className="flex justify-around py-2">
         <li>
-          <Link href="/" className="flex flex-col items-center text-gray-700 hover:text-blue-500">
-            <FaHome size={24} />
-            <span className="mt-1 text-xs">홈</span>
+          <Link
+            href="/convert/media"
+            className="flex flex-col items-center text-gray-700 hover:text-blue-500"
+          >
+            <FaPhotoVideo size={24} />
+            <span className="mt-1 text-xs">미디어 변환</span>
           </Link>
         </li>
         <li>
-          <Link href="/convert" className="flex flex-col items-center text-gray-700 hover:text-blue-500">
-            <FaExchangeAlt size={24} />
-            <span className="mt-1 text-xs">변환</span>
-          </Link>
-        </li>
-        <li>
-          <Link href="/account" className="flex flex-col items-center text-gray-700 hover:text-blue-500">
-            <FaUser size={24} />
-            <span className="mt-1 text-xs">계정</span>
+          <Link
+            href="/convert/pdf"
+            className="flex flex-col items-center text-gray-700 hover:text-blue-500"
+          >
+            <FaFilePdf size={24} />
+            <span className="mt-1 text-xs">PDF 변환</span>
           </Link>
         </li>
       </ul>

--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -60,7 +60,11 @@ const handleGoogleLogin = () => {
   }
 };
 
-export default function Converter() {
+interface ConverterProps {
+  showModeSelector?: boolean;
+}
+
+export default function Converter({ showModeSelector = true }: ConverterProps) {
   const { data: session, status } = useSession();
   const [mode, setMode] = useState<'media' | 'pdf'>('media');
   const [file, setFile] = useState<File | null>(null);
@@ -579,13 +583,19 @@ export default function Converter() {
 
       <p className="subtitle">비디오, 오디오, 이미지 파일을 다양한 형식으로 변환하세요</p>
 
-      <div className="format-section">
-        <label htmlFor="mode">메뉴 선택:</label>
-        <select id="mode" value={mode} onChange={(e) => setMode(e.target.value as 'media' | 'pdf')}>
-          <option value="media">미디어 변환</option>
-          <option value="pdf">PDF 변환</option>
-        </select>
-      </div>
+      {showModeSelector && (
+        <div className="format-section">
+          <label htmlFor="mode">메뉴 선택:</label>
+          <select
+            id="mode"
+            value={mode}
+            onChange={(e) => setMode(e.target.value as 'media' | 'pdf')}
+          >
+            <option value="media">미디어 변환</option>
+            <option value="pdf">PDF 변환</option>
+          </select>
+        </div>
+      )}
 
       {mode === 'media' && (
       <form


### PR DESCRIPTION
## Summary
- 변환 메뉴를 분리하기 위해 `/convert/media`와 `/convert/pdf` 페이지 신설
- 변환 하위 페이지 공통 레이아웃에 BottomNav 고정 추가
- BottomNav 컴포넌트를 미디어/PDF 전환 전용으로 변경
- 기본 `/convert` 경로는 `/convert/media`로 리다이렉트
- Converter 컴포넌트에 `showModeSelector` 옵션 도입

## Testing
- `npm run lint`
- `npm test` *(실패: jest 환경 문제)*
- `npm run build` *(실패: Google Fonts 차단)*
- `npm start` *(실패: 빌드 실패로 시작 불가)*

------
https://chatgpt.com/codex/tasks/task_e_685eb2f1f764832a890b2ec8612dc8d7