### PR TITLE
PDF 변환 페이지 UI 개선

### DIFF
--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { useSession, signIn, signOut } from 'next-auth/react';
+import { useSession, signIn } from 'next-auth/react';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { toBlobURL } from '@ffmpeg/util';
 import { FaSpinner } from 'react-icons/fa';
 
 import LoginCard from '@/components/LoginCard';
 import PdfConverter from '@/components/PdfConverter';
+import Header from '@/components/Header';
 
 interface ConversionResult {
   url: string;
@@ -569,19 +570,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
   return (
     <div className="container" suppressHydrationWarning={true}>
       {/* 헤더 */}
-      <div className="header">
-        <div className="header-content">
-          <h1 className="select-none">QuokkaConvert</h1>
-          <div className="user-info">
-            <span className="user-email">{session.user?.email}</span>
-            <button onClick={() => signOut({ callbackUrl: '/' })} className="logout-btn">
-              로그아웃
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <p className="subtitle">비디오, 오디오, 이미지 파일을 다양한 형식으로 변환하세요</p>
+      <Header subtitle="비디오, 오디오, 이미지 파일을 다양한 형식으로 변환하세요" />
 
       {showModeSelector && (
         <div className="format-section">

--- a/next-converter/src/components/Header.tsx
+++ b/next-converter/src/components/Header.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { useSession, signOut } from 'next-auth/react';
+
+interface HeaderProps {
+  subtitle: string;
+}
+
+export default function Header({ subtitle }: HeaderProps) {
+  const { data: session } = useSession();
+  return (
+    <>
+      <div className="header">
+        <div className="header-content">
+          <h1 className="select-none">QuokkaConvert</h1>
+          {session && (
+            <div className="user-info">
+              <span className="user-email">{session.user?.email}</span>
+              <button onClick={() => signOut({ callbackUrl: '/' })} className="logout-btn">
+                로그아웃
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+      <p className="subtitle">{subtitle}</p>
+    </>
+  );
+}

--- a/next-converter/src/components/PdfConverter.tsx
+++ b/next-converter/src/components/PdfConverter.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import Header from '@/components/Header';
 
 export default function PdfConverter() {
   const [operation, setOperation] = useState<'images' | 'merge' | 'split'>('images');
@@ -59,32 +60,34 @@ export default function PdfConverter() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div className="format-section">
-        <label htmlFor="operation">작업 선택:</label>
-        <select
-          id="operation"
-          value={operation}
-          onChange={(e) =>
-            setOperation(e.target.value as 'images' | 'merge' | 'split')
-          }
-        >
-          <option value="images">이미지 → PDF</option>
-          <option value="merge">PDF 병합</option>
-          <option value="split">페이지 분리</option>
-        </select>
-      </div>
-      <div className="file-section">
-        <label htmlFor="pdfFiles">파일 업로드:</label>
-        <input
-          id="pdfFiles"
-          type="file"
-          multiple={operation !== 'split'}
-          accept={operation === 'images' ? 'image/*' : 'application/pdf'}
-          onChange={handleChange}
-          required
-        />
-      </div>
+    <div className="container">
+      <Header subtitle="이미지 → PDF 변환과 병합 및 분할 기능을 제공합니다" />
+      <form onSubmit={handleSubmit}>
+        <div className="file-section">
+          <label htmlFor="pdfFiles">파일 업로드:</label>
+          <input
+            id="pdfFiles"
+            type="file"
+            multiple={operation !== 'split'}
+            accept={operation === 'images' ? 'image/*' : 'application/pdf'}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="format-section">
+          <label htmlFor="operation">작업 선택:</label>
+          <select
+            id="operation"
+            value={operation}
+            onChange={(e) =>
+              setOperation(e.target.value as 'images' | 'merge' | 'split')
+            }
+          >
+            <option value="images">이미지 → PDF</option>
+            <option value="merge">PDF 병합</option>
+            <option value="split">페이지 분리</option>
+          </select>
+        </div>
       {operation === 'split' && (
         <div className="option-row">
           <label htmlFor="page">페이지 번호:</label>
@@ -110,9 +113,10 @@ export default function PdfConverter() {
           </button>
         </div>
       )}
-      <button type="submit" disabled={loading}>
-        {loading ? '처리 중...' : '실행'}
-      </button>
-    </form>
+        <button type="submit" disabled={loading}>
+          {loading ? '처리 중...' : '실행'}
+        </button>
+      </form>
+    </div>
   );
 }

--- a/next-converter/src/components/__tests__/PdfConverter.test.tsx
+++ b/next-converter/src/components/__tests__/PdfConverter.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import PdfConverter from '../PdfConverter';
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+  signOut: jest.fn(),
+}));
 
 describe('PdfConverter component', () => {
   test('shows page input when split selected', () => {


### PR DESCRIPTION
## 요약
- 공통 헤더 컴포넌트 추가
- Converter/PdfConverter에서 새로운 헤더 사용
- PdfConverter 구조 변경 및 설명 추가
- 테스트 코드에서 next-auth 모킹

## 테스트
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(실패: Google Fonts 차단)*
- `npm start` *(실패: 빌드 결과 없음)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5c9c2f4832a9e30509464fd9cd7