### PR TITLE
하단 네비게이션 UI 개선

### DIFF
--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { FaHome, FaPhotoVideo, FaFilePdf } from 'react-icons/fa';
+import { FaHome, FaImage, FaFilePdf } from 'react-icons/fa';
 import { useEffect, useState } from 'react';
 
 export default function BottomNav() {
@@ -26,22 +26,22 @@ export default function BottomNav() {
 
   const tabs = [
     { href: '/convert', icon: <FaHome size={20} />, label: '홈' },
-    { href: '/convert/media', icon: <FaPhotoVideo size={20} />, label: '미디어 변환' },
-    { href: '/convert/pdf', icon: <FaFilePdf size={20} />, label: 'PDF 변환' },
+    { href: '/convert/media', icon: <FaImage size={20} />, label: '미디어' },
+    { href: '/convert/pdf', icon: <FaFilePdf size={20} />, label: 'PDF' },
   ];
 
   return (
     <nav
-      className={`fixed bottom-0 left-0 right-0 border-t border-gray-200 bg-white shadow-md transition-all duration-300 ease-in-out ${visible ? 'opacity-100 translate-y-0' : 'pointer-events-none opacity-0 translate-y-full'}`}
+      className={`fixed bottom-0 left-0 right-0 border-t border-neutral-700 bg-neutral-900 shadow-md transition-all duration-300 ease-in-out ${visible ? 'opacity-100 translate-y-0' : 'pointer-events-none opacity-0 translate-y-full'}`}
     >
-      <ul className="flex">
+      <ul className="flex justify-center gap-x-6 py-2">
         {tabs.map(({ href, icon, label }) => {
           const active = pathname === href || (href !== '/convert' && pathname.startsWith(href));
           return (
-            <li key={href} className="flex-1">
+            <li key={href}>
               <Link
                 href={href}
-                className={`flex h-12 flex-col items-center justify-center text-sm transition-colors ${active ? 'text-blue-600' : 'text-gray-500 hover:text-blue-500'}`}
+                className={`flex min-h-[48px] min-w-[64px] flex-col items-center justify-center whitespace-nowrap rounded-md px-4 text-sm transition-colors ${active ? 'border-t-2 border-blue-500 text-white' : 'text-gray-400 hover:text-white'}`}
               >
                 {icon}
                 <span className="mt-1">{label}</span>


### PR DESCRIPTION
## 요약
- 하단 네비게이션 버튼 구성을 개선해 가독성을 높였습니다.
- 탭 간 간격을 확보하고 선택 상태에서 강조 효과를 주었습니다.
- 아이콘과 라벨을 간결하게 수정했습니다.

## 변경 내용
- `react-icons` 사용 아이콘 일부 교체
- 배경을 다크 톤으로 변경하고 선택된 탭에 테두리와 색상을 적용
- 터치 타겟 크기와 공백을 확보하여 사용성을 향상

## 테스트 결과
- `npm run lint`: 통과
- `npx tsc --noEmit`: 통과
- `npm run build`: 폰트 다운로드 문제로 실패
- `npm start`: 빌드 파일이 없어 실패
- `npm test`: jest 환경 모듈 누락으로 실패

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685eba63f9c0832aa9899a93f56dddae