### PR TITLE
Convert JS utilities to TypeScript

### DIFF
--- a/next-converter/src/lib/ffmpegWasm.ts
+++ b/next-converter/src/lib/ffmpegWasm.ts
@@ -1,10 +1,18 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { toBlobURL } from '@ffmpeg/util';
 
-let ffmpeg = null;
+export interface WasmConvertOptions {
+  resolution?: string;
+  fps?: number;
+  bitrate?: string;
+  quality?: '낮음' | '보통' | '높음';
+  playbackSpeed?: number;
+}
+
+let ffmpeg: FFmpeg | null = null;
 
 // FFmpeg 초기화
-export async function initFFmpeg() {
+export async function initFFmpeg(): Promise<FFmpeg> {
   if (ffmpeg) return ffmpeg;
 
   const base = process.env.NEXT_PUBLIC_FFMPEG_BASE_URL ?? '/ffmpeg';
@@ -32,7 +40,12 @@ export async function initFFmpeg() {
 }
 
 // 파일 변환 함수
-export async function convertFileWithWasm(inputBuffer, inputFormat, outputFormat, options = {}) {
+export async function convertFileWithWasm(
+  inputBuffer: ArrayBuffer,
+  inputFormat: string,
+  outputFormat: string,
+  options: WasmConvertOptions = {}
+): Promise<{ data: Uint8Array; size: number }> {
   try {
     const ffmpegInstance = await initFFmpeg();
 
@@ -116,7 +129,7 @@ export const SUPPORTED_FORMATS = {
 };
 
 // 변환 지원 여부 확인
-export function isConversionSupported(inputFormat, outputFormat) {
+export function isConversionSupported(inputFormat: string, outputFormat: string): boolean {
   const inputExt = inputFormat.toLowerCase();
   const outputExt = outputFormat.toLowerCase();
 

--- a/next-converter/src/lib/universalConverter.ts
+++ b/next-converter/src/lib/universalConverter.ts
@@ -3,6 +3,20 @@ import fs from 'fs';
 import path from 'path';
 import ffmpeg from 'ffmpeg-static';
 
+export interface ConvertOptions {
+  input: string;
+  output?: string;
+  format?: string;
+  resolution?: string;
+  fps?: number;
+  bitrate?: string;
+  codec?: string;
+  quality?: '낮음' | '보통' | '높음';
+  sampleRate?: number;
+  channels?: number;
+  playbackSpeed?: number;
+}
+
 // FFmpeg 경로 확인 및 수정
 const getFFmpegPath = () => {
   if (!ffmpeg) {
@@ -49,7 +63,7 @@ export const SUPPORTED_FORMATS = {
 };
 
 // 파일 타입 감지
-function detectFileType(filename) {
+function detectFileType(filename: string): 'video' | 'audio' | 'image' | null {
   const ext = path.extname(filename).toLowerCase().slice(1);
   
   if (SUPPORTED_FORMATS.video.input.includes(ext) || SUPPORTED_FORMATS.video.output.includes(ext)) {
@@ -64,7 +78,7 @@ function detectFileType(filename) {
 }
 
 // FFmpeg 의존성 확인 (서버리스 환경에서는 항상 사용 가능)
-function checkFFmpeg() {
+function checkFFmpeg(): string {
   try {
     const ffmpegPath = getFFmpegPath();
     console.log('FFmpeg 경로:', ffmpegPath);
@@ -76,7 +90,7 @@ function checkFFmpeg() {
 }
 
 // 비디오 변환 (최적화)
-function convertVideo(inputPath, outputPath, options = {}) {
+function convertVideo(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
   const {
     resolution,
     fps,
@@ -267,7 +281,7 @@ function convertVideo(inputPath, outputPath, options = {}) {
 }
 
 // 오디오 변환 (최적화)
-function convertAudio(inputPath, outputPath, options = {}) {
+function convertAudio(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
   const {
     bitrate,
     sampleRate,
@@ -434,7 +448,7 @@ function convertAudio(inputPath, outputPath, options = {}) {
 }
 
 // 이미지 변환 (최적화)
-function convertImage(inputPath, outputPath, options = {}) {
+function convertImage(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
   const {
     resolution,
     quality
@@ -514,7 +528,7 @@ function convertImage(inputPath, outputPath, options = {}) {
 }
 
 // GIF 특별 처리 (최적화)
-function convertToGif(inputPath, outputPath, options = {}) {
+function convertToGif(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
   const {
     resolution,
     fps = 10,
@@ -618,7 +632,7 @@ function convertToGif(inputPath, outputPath, options = {}) {
 }
 
 // 메인 변환 함수
-export async function convertFile(options) {
+export async function convertFile(options: ConvertOptions): Promise<{ output: string; size: number }> {
   const {
     input,
     output,
@@ -669,7 +683,7 @@ export async function convertFile(options) {
 }
 
 // 지원하는 변환 조합 확인
-export function isConversionSupported(inputFormat, outputFormat) {
+export function isConversionSupported(inputFormat: string, outputFormat: string): boolean {
   const inputType = detectFileType(`file.${inputFormat}`);
   const outputType = detectFileType(`file.${outputFormat}`);
   

--- a/server/movToGif.ts
+++ b/server/movToGif.ts
@@ -1,8 +1,20 @@
 import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 
-function check_dependencies() {
-  const missing = [];
+export interface MovToGifOptions {
+  input: string;
+  output?: string;
+  framerate?: number;
+  loop?: number;
+  optimize?: number;
+  width?: number;
+  scale?: string;
+  delay?: number;
+  quality?: '낮음' | '보통' | '높음';
+}
+
+function check_dependencies(): void {
+  const missing: string[] = [];
   try { execSync('ffmpeg -version', { stdio: 'ignore' }); } catch { missing.push('ffmpeg'); }
   try { execSync('gifsicle --version', { stdio: 'ignore' }); } catch { missing.push('gifsicle'); }
   if (missing.length > 0) {
@@ -10,7 +22,7 @@ function check_dependencies() {
   }
 }
 
-function apply_quality_preset(preset, state) {
+function apply_quality_preset(preset: '낮음' | '보통' | '높음', state: MovToGifOptions): void {
   switch (preset) {
     case '낮음':
       state.framerate = 8; state.optimize = 1;
@@ -28,8 +40,8 @@ function apply_quality_preset(preset, state) {
   }
 }
 
-export async function movToGif(options) {
-  const state = { ...options };
+export async function movToGif(options: MovToGifOptions): Promise<{ output: string; size: number }> {
+  const state: MovToGifOptions = { ...options };
   if (state.loop === undefined) state.loop = 0;
   if (!state.input) throw new Error('입력 파일이 지정되지 않았습니다.');
   if (!fs.existsSync(state.input)) throw new Error(`입력 파일을 찾을 수 없습니다: ${state.input}`);

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,7 +3,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { convertFile, SUPPORTED_FORMATS, isConversionSupported } from './universalConverter.js';
+import { convertFile, SUPPORTED_FORMATS, isConversionSupported } from './universalConverter';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/server/universalConverter.ts
+++ b/server/universalConverter.ts
@@ -2,6 +2,34 @@ import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+export interface VideoOptions {
+  resolution?: string;
+  fps?: number;
+  bitrate?: string;
+  codec?: string;
+  quality?: '낮음' | '보통' | '높음';
+}
+
+export interface AudioOptions {
+  bitrate?: string;
+  sampleRate?: number;
+  channels?: number;
+  codec?: string;
+  quality?: '낮음' | '보통' | '높음';
+}
+
+export interface ImageOptions {
+  resolution?: string;
+  quality?: '낮음' | '보통' | '높음';
+  format?: string;
+}
+
+export interface ConvertOptions extends VideoOptions, AudioOptions, ImageOptions {
+  input: string;
+  output?: string;
+  format?: string;
+}
+
 // 지원하는 포맷 정의
 export const SUPPORTED_FORMATS = {
   video: {
@@ -19,7 +47,7 @@ export const SUPPORTED_FORMATS = {
 };
 
 // 파일 타입 감지
-function detectFileType(filename) {
+function detectFileType(filename: string): 'video' | 'audio' | 'image' | null {
   const ext = path.extname(filename).toLowerCase().slice(1);
   
   if (SUPPORTED_FORMATS.video.input.includes(ext) || SUPPORTED_FORMATS.video.output.includes(ext)) {
@@ -34,7 +62,7 @@ function detectFileType(filename) {
 }
 
 // FFmpeg 의존성 확인
-function checkFFmpeg() {
+function checkFFmpeg(): boolean {
   try {
     execSync('ffmpeg -version', { stdio: 'ignore' });
     return true;
@@ -44,7 +72,7 @@ function checkFFmpeg() {
 }
 
 // 비디오 변환
-function convertVideo(inputPath, outputPath, options = {}) {
+function convertVideo(inputPath: string, outputPath: string, options: VideoOptions = {}): { output: string; size: number } {
   const {
     resolution,
     fps,
@@ -102,7 +130,7 @@ function convertVideo(inputPath, outputPath, options = {}) {
 }
 
 // 오디오 변환
-function convertAudio(inputPath, outputPath, options = {}) {
+function convertAudio(inputPath: string, outputPath: string, options: AudioOptions = {}): { output: string; size: number } {
   const {
     bitrate,
     sampleRate,
@@ -157,7 +185,7 @@ function convertAudio(inputPath, outputPath, options = {}) {
 }
 
 // 이미지 변환
-function convertImage(inputPath, outputPath, options = {}) {
+function convertImage(inputPath: string, outputPath: string, options: ImageOptions = {}): { output: string; size: number } {
   const {
     resolution,
     quality,
@@ -195,7 +223,7 @@ function convertImage(inputPath, outputPath, options = {}) {
 }
 
 // GIF 특별 처리 (최적화)
-function convertToGif(inputPath, outputPath, options = {}) {
+function convertToGif(inputPath: string, outputPath: string, options: { resolution?: string; fps?: number; optimize?: number } = {}): { output: string; size: number } {
   const {
     resolution,
     fps = 10,
@@ -252,7 +280,7 @@ function convertToGif(inputPath, outputPath, options = {}) {
 }
 
 // 메인 변환 함수
-export async function convertFile(options) {
+export async function convertFile(options: ConvertOptions): Promise<{ output: string; size: number }> {
   const {
     input,
     output,
@@ -302,7 +330,7 @@ export async function convertFile(options) {
 }
 
 // 지원하는 변환 조합 확인
-export function isConversionSupported(inputFormat, outputFormat) {
+export function isConversionSupported(inputFormat: string, outputFormat: string): boolean {
   const inputType = detectFileType(`file.${inputFormat}`);
   const outputType = detectFileType(`file.${outputFormat}`);
   


### PR DESCRIPTION
## Summary
- lib 및 server 폴더의 js 파일을 ts로 마이그레이션
- 관련 옵션 인터페이스를 정의하여 타입 안정성 확보
- 서버 코드 import 경로 수정

## Testing
- `npm run build`
- `npm start`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861eec2d528832ab458c2a832ccba01