### PR TITLE
Fix TypeScript errors in convert API

### DIFF
--- a/next-converter/src/app/api/convert/route.ts
+++ b/next-converter/src/app/api/convert/route.ts
@@ -135,14 +135,13 @@ export async function POST(request: NextRequest) {
 
     // 파일을 ArrayBuffer로 변환
     const arrayBuffer = await file.arrayBuffer();
-    const buffer = new Uint8Array(arrayBuffer);
 
     // 변환 옵션 구성
     const convertOptions: {
       resolution?: string;
       fps?: number;
       bitrate?: string;
-      quality?: string;
+      quality?: '낮음' | '보통' | '높음';
       sampleRate?: number;
       channels?: number;
       codec?: string;
@@ -162,7 +161,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (quality && ['낮음', '보통', '높음'].includes(quality)) {
-      convertOptions.quality = quality;
+      convertOptions.quality = quality as '낮음' | '보통' | '높음';
     }
 
     if (sampleRate) {
@@ -185,7 +184,7 @@ export async function POST(request: NextRequest) {
 
     // 타임아웃 설정으로 비용 제어
     const conversionPromise = convertFileWithWasm(
-      buffer,
+      arrayBuffer,
       inputExt,
       targetFormat,
       convertOptions

--- a/next-converter/src/lib/ffmpegWasm.ts
+++ b/next-converter/src/lib/ffmpegWasm.ts
@@ -91,7 +91,7 @@ export async function convertFileWithWasm(
     await ffmpegInstance.exec(args);
 
     // 결과 파일 읽기
-    const outputData = await ffmpegInstance.readFile(outputFileName);
+    const outputData = await ffmpegInstance.readFile(outputFileName) as Uint8Array;
 
     // 임시 파일 정리
     try {
@@ -108,7 +108,8 @@ export async function convertFileWithWasm(
 
   } catch (error) {
     console.error('FFmpeg WebAssembly 변환 오류:', error);
-    throw new Error(`파일 변환에 실패했습니다: ${error.message}`);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`파일 변환에 실패했습니다: ${message}`);
   }
 }
 

--- a/next-converter/src/lib/universalConverter.ts
+++ b/next-converter/src/lib/universalConverter.ts
@@ -90,7 +90,11 @@ function checkFFmpeg(): string {
 }
 
 // 비디오 변환 (최적화)
-function convertVideo(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
+function convertVideo(
+  inputPath: string,
+  outputPath: string,
+  options: Partial<Omit<ConvertOptions, 'input' | 'output'>> = {}
+): { output: string; size: number } {
   const {
     resolution,
     fps,
@@ -281,7 +285,11 @@ function convertVideo(inputPath: string, outputPath: string, options: ConvertOpt
 }
 
 // 오디오 변환 (최적화)
-function convertAudio(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
+function convertAudio(
+  inputPath: string,
+  outputPath: string,
+  options: Partial<Omit<ConvertOptions, 'input' | 'output'>> = {}
+): { output: string; size: number } {
   const {
     bitrate,
     sampleRate,
@@ -448,7 +456,11 @@ function convertAudio(inputPath: string, outputPath: string, options: ConvertOpt
 }
 
 // 이미지 변환 (최적화)
-function convertImage(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
+function convertImage(
+  inputPath: string,
+  outputPath: string,
+  options: Partial<Omit<ConvertOptions, 'input' | 'output'>> = {}
+): { output: string; size: number } {
   const {
     resolution,
     quality
@@ -528,7 +540,11 @@ function convertImage(inputPath: string, outputPath: string, options: ConvertOpt
 }
 
 // GIF 특별 처리 (최적화)
-function convertToGif(inputPath: string, outputPath: string, options: ConvertOptions = {}): { output: string; size: number } {
+function convertToGif(
+  inputPath: string,
+  outputPath: string,
+  options: Partial<Omit<ConvertOptions, 'input' | 'output'>> = {}
+): { output: string; size: number } {
   const {
     resolution,
     fps = 10,
@@ -539,7 +555,7 @@ function convertToGif(inputPath: string, outputPath: string, options: ConvertOpt
   console.log('GIF 변환 시작:', { inputPath, outputPath, options });
 
   const ffmpegPath = checkFFmpeg();
-  let filters = [];
+  const filters: string[] = [];
   
   // 재생속도 조절 (setpts 필터 사용)
   if (playbackSpeed !== 1.0) {


### PR DESCRIPTION
## Summary
- WASM 변환 함수 호출 시 ArrayBuffer 사용하도록 수정
- FFmpeg WASM 출력 타입 지정 및 예외 처리 강화
- GIF 변환 필터 배열을 const로 선언
- 기타 타입 정의 보완

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6861f4c65e84832a84c213d01e3f499f