### PR TITLE
Refactor code reuse

### DIFF
--- a/next-converter/src/app/convert/media/page.tsx
+++ b/next-converter/src/app/convert/media/page.tsx
@@ -1,11 +1,7 @@
 import Converter from '@/components/Converter';
-import { auth } from '@/auth';
-import { redirect } from 'next/navigation';
+import requireAuth from '@/lib/requireAuth';
 
 export default async function MediaConvertPage() {
-  const session = await auth();
-  if (!session) {
-    redirect('/');
-  }
+  await requireAuth();
   return <Converter showModeSelector={false} />;
 }

--- a/next-converter/src/app/convert/pdf/page.tsx
+++ b/next-converter/src/app/convert/pdf/page.tsx
@@ -1,11 +1,7 @@
 import PdfConverter from '@/components/PdfConverter';
-import { auth } from '@/auth';
-import { redirect } from 'next/navigation';
+import requireAuth from '@/lib/requireAuth';
 
 export default async function PdfConvertPage() {
-  const session = await auth();
-  if (!session) {
-    redirect('/');
-  }
+  await requireAuth();
   return <PdfConverter />;
 }

--- a/next-converter/src/app/page.tsx
+++ b/next-converter/src/app/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { useEffect } from 'react';
-import { useSession, signIn } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { FaSpinner } from 'react-icons/fa';
+import Loading from '@/components/Loading';
 import LoginCard from '@/components/LoginCard';
+import { loginWithGoogle } from '@/lib/utils';
 
 const handleGoogleLogin = () => {
-  signIn('google', { callbackUrl: '/convert' });
+  loginWithGoogle();
 };
 
 export default function Home() {
@@ -20,14 +21,7 @@ export default function Home() {
   }, [session, router]);
 
   if (status === 'loading') {
-    return (
-      <div className="flex min-h-screen items-center justify-center ">
-        <div className="text-center">
-          <FaSpinner className="mx-auto mb-4 h-8 w-8 animate-spin text-blue-500" />
-          <p className="text-sm text-gray-600">로딩 중...</p>
-        </div>
-      </div>
-    );
+    return <Loading />;
   }
 
   return <LoginCard onLogin={handleGoogleLogin} />;

--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { useSession, signIn } from 'next-auth/react';
-import { FaSpinner } from 'react-icons/fa';
+import { useSession } from 'next-auth/react';
+import Loading from '@/components/Loading';
+import { loginWithGoogle, downloadBlob } from '@/lib/utils';
 
 import LoginCard from '@/components/LoginCard';
 import PdfConverter from '@/components/PdfConverter';
@@ -30,7 +31,7 @@ const detectFileType = (filename: string) => {
 };
 
 const handleGoogleLogin = () => {
-  signIn('google', { callbackUrl: '/convert' });
+  loginWithGoogle();
 };
 
 interface ConverterProps {
@@ -285,15 +286,8 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
   // 변환된 파일 다운로드
   const handleDownload = useCallback(() => {
     if (convertedFile) {
-      const url = URL.createObjectURL(convertedFile);
-      const a = document.createElement('a');
-      a.href = url;
       const format = result?.format || outputFormat;
-      a.download = `converted.${format}`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(convertedFile, `converted.${format}`);
     }
   }, [convertedFile, result, outputFormat]);
 
@@ -443,14 +437,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
 
   // 로그인 상태 확인
   if (status === 'loading') {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
-          <FaSpinner className="mx-auto mb-4 h-8 w-8 animate-spin text-blue-500" />
-          <p className="text-sm text-gray-600">로딩 중...</p>
-        </div>
-      </div>
-    );
+    return <Loading />;
   }
 
   if (!session) {

--- a/next-converter/src/components/Loading.tsx
+++ b/next-converter/src/components/Loading.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { FaSpinner } from 'react-icons/fa';
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <FaSpinner className="mx-auto mb-4 h-8 w-8 animate-spin text-blue-500" />
+        <p className="text-sm text-gray-600">로딩 중...</p>
+      </div>
+    </div>
+  );
+}

--- a/next-converter/src/components/PdfConverter.tsx
+++ b/next-converter/src/components/PdfConverter.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import Header from '@/components/Header';
+import { downloadBlob } from '@/lib/utils';
 
 export default function PdfConverter() {
   const [operation, setOperation] = useState<'images' | 'merge' | 'split'>('images');
@@ -49,14 +50,7 @@ export default function PdfConverter() {
 
   const download = () => {
     if (!result) return;
-    const url = URL.createObjectURL(result);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'result.pdf';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadBlob(result, 'result.pdf');
   };
 
   return (

--- a/next-converter/src/lib/requireAuth.ts
+++ b/next-converter/src/lib/requireAuth.ts
@@ -1,0 +1,10 @@
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+
+export default async function requireAuth() {
+  const session = await auth();
+  if (!session) {
+    redirect('/');
+  }
+  return session;
+}

--- a/next-converter/src/lib/utils.ts
+++ b/next-converter/src/lib/utils.ts
@@ -1,0 +1,17 @@
+'use client';
+import { signIn } from 'next-auth/react';
+
+export function loginWithGoogle() {
+  signIn('google', { callbackUrl: '/convert' });
+}
+
+export function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## 요약
- 중복 로딩 UI를 `Loading` 컴포넌트로 분리
- Google 로그인과 파일 다운로드 로직을 유틸 함수로 정리
- 인증 확인 로직을 `requireAuth` 함수로 추출
- 관련 페이지와 컴포넌트에서 새 유틸/컴포넌트 사용

## 테스트
- `npm run lint`
- `npm run build`
- `npm start`
- `npm test` (실패)


------
https://chatgpt.com/codex/tasks/task_e_6862038e86dc832aaab145caecf976fc