### PR TITLE
중복 코드 함수화 및 컴포넌트화

### DIFF
--- a/next-converter/src/app/page.tsx
+++ b/next-converter/src/app/page.tsx
@@ -6,10 +6,6 @@ import Loading from '@/components/Loading';
 import LoginCard from '@/components/LoginCard';
 import { loginWithGoogle } from '@/lib/utils';
 
-const handleGoogleLogin = () => {
-  loginWithGoogle();
-};
-
 export default function Home() {
   const { data: session, status } = useSession();
   const router = useRouter();
@@ -24,5 +20,5 @@ export default function Home() {
     return <Loading />;
   }
 
-  return <LoginCard onLogin={handleGoogleLogin} />;
+  return <LoginCard onLogin={loginWithGoogle} />;
 }

--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -8,6 +8,7 @@ import { loginWithGoogle, downloadBlob } from '@/lib/utils';
 import LoginCard from '@/components/LoginCard';
 import PdfConverter from '@/components/PdfConverter';
 import Header from '@/components/Header';
+import ErrorMessage from '@/components/ErrorMessage';
 import { convertFileWithWasm, initFFmpeg } from '@/lib/ffmpegWasm';
 
 interface ConversionResult {
@@ -30,9 +31,6 @@ const detectFileType = (filename: string) => {
   return 'unknown';
 };
 
-const handleGoogleLogin = () => {
-  loginWithGoogle();
-};
 
 interface ConverterProps {
   showModeSelector?: boolean;
@@ -441,7 +439,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
   }
 
   if (!session) {
-    return <LoginCard onLogin={handleGoogleLogin} />;
+    return <LoginCard onLogin={loginWithGoogle} />;
   }
 
   return (
@@ -875,12 +873,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
         </div>
       )}
 
-      {error && (
-        <div className="error-message">
-          <h3>오류 발생</h3>
-          <p>{error}</p>
-        </div>
-      )}
+      {error && <ErrorMessage title="오류 발생" message={error} />}
     </div>
   );
 }

--- a/next-converter/src/components/ErrorMessage.tsx
+++ b/next-converter/src/components/ErrorMessage.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+interface ErrorMessageProps {
+  message: string;
+  title?: string;
+}
+
+export default function ErrorMessage({ message, title }: ErrorMessageProps) {
+  return (
+    <div className="error-message">
+      {title && <h3>{title}</h3>}
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/next-converter/src/components/PdfConverter.tsx
+++ b/next-converter/src/components/PdfConverter.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import Header from '@/components/Header';
 import { downloadBlob } from '@/lib/utils';
+import ErrorMessage from '@/components/ErrorMessage';
 
 export default function PdfConverter() {
   const [operation, setOperation] = useState<'images' | 'merge' | 'split'>('images');
@@ -92,11 +93,7 @@ export default function PdfConverter() {
             />
           </div>
         )}
-        {error && (
-          <div className="error-message">
-            <p>{error}</p>
-          </div>
-        )}
+        {error && <ErrorMessage message={error} />}
         {result && (
           <div className="result">
             <h2>완료</h2>


### PR DESCRIPTION
## 변경 내용
- 로그인 처리 중복 함수를 제거하고 `loginWithGoogle` 직접 사용
- 반복되는 오류 표시 부분을 `ErrorMessage` 컴포넌트로 분리
- 각 페이지와 컴포넌트에서 새 컴포넌트를 사용하도록 수정

## 테스트 결과
- `npm run lint` 성공
- `npm run build` 및 `npm start` 정상 동작 확인
- `npm install` 및 `tsc` 명령은 네트워크 제한으로 실행되지 않음

------
https://chatgpt.com/codex/tasks/task_e_68620b3ad854832a8deb0dd5f3009ab6