### PR TITLE
Refactor file type utilities

### DIFF
--- a/next-converter/src/app/api/check-conversion/route.ts
+++ b/next-converter/src/app/api/check-conversion/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { isConversionSupported } from '@/lib/universalConverter';
+import { isConversionSupported } from '@/lib/utils/fileFormats';
 
 export async function POST(request: NextRequest) {
   try {

--- a/next-converter/src/app/api/convert/route.ts
+++ b/next-converter/src/app/api/convert/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
-import { convertFileWithWasm, SUPPORTED_FORMATS } from '@/lib/ffmpegWasm';
+import { convertFileWithWasm } from '@/lib/ffmpegWasm';
+import { SUPPORTED_FORMATS } from '@/lib/utils/fileFormats';
 
 // 비용 제어를 위한 제한 설정 (Vercel 배포용)
 const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4MB (Vercel 제한)

--- a/next-converter/src/app/api/formats/route.ts
+++ b/next-converter/src/app/api/formats/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { SUPPORTED_FORMATS } from '@/lib/universalConverter';
+import { SUPPORTED_FORMATS } from '@/lib/utils/fileFormats';
 
 export async function GET() {
   return NextResponse.json(SUPPORTED_FORMATS);

--- a/next-converter/src/lib/ffmpegWasm.ts
+++ b/next-converter/src/lib/ffmpegWasm.ts
@@ -1,6 +1,7 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { toBlobURL } from '@ffmpeg/util';
 
+
 export interface WasmConvertOptions {
   resolution?: string;
   fps?: number;
@@ -114,43 +115,3 @@ export async function convertFileWithWasm(
 }
 
 // 지원하는 포맷 정의
-export const SUPPORTED_FORMATS = {
-  video: {
-    input: ['mp4', 'avi', 'mov', 'mkv', 'webm', 'flv', 'wmv', 'm4v', '3gp'],
-    output: ['mp4', 'avi', 'mov', 'mkv', 'webm', 'gif', 'flv', 'wmv', 'm4v', '3gp']
-  },
-  audio: {
-    input: ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'wma', 'opus'],
-    output: ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'wma', 'opus']
-  },
-  image: {
-    input: ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'tiff', 'webp', 'svg'],
-    output: ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'tiff', 'webp']
-  }
-};
-
-// 변환 지원 여부 확인
-export function isConversionSupported(inputFormat: string, outputFormat: string): boolean {
-  const inputExt = inputFormat.toLowerCase();
-  const outputExt = outputFormat.toLowerCase();
-
-  // 비디오 변환
-  if (SUPPORTED_FORMATS.video.input.includes(inputExt) &&
-    SUPPORTED_FORMATS.video.output.includes(outputExt)) {
-    return true;
-  }
-
-  // 오디오 변환
-  if (SUPPORTED_FORMATS.audio.input.includes(inputExt) &&
-    SUPPORTED_FORMATS.audio.output.includes(outputExt)) {
-    return true;
-  }
-
-  // 이미지 변환
-  if (SUPPORTED_FORMATS.image.input.includes(inputExt) &&
-    SUPPORTED_FORMATS.image.output.includes(outputExt)) {
-    return true;
-  }
-
-  return false;
-} 

--- a/next-converter/src/lib/universalConverter.ts
+++ b/next-converter/src/lib/universalConverter.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import ffmpeg from 'ffmpeg-static';
+import { detectFileType } from './utils/fileFormats';
 
 export interface ConvertOptions {
   input: string;
@@ -46,36 +47,7 @@ const getFFmpegPath = () => {
   throw new Error('FFmpeg 실행 파일을 찾을 수 없습니다.');
 };
 
-// 지원하는 포맷 정의
-export const SUPPORTED_FORMATS = {
-  video: {
-    input: ['mp4', 'avi', 'mov', 'mkv', 'webm', 'flv', 'wmv', 'm4v', '3gp'],
-    output: ['mp4', 'avi', 'mov', 'mkv', 'webm', 'gif', 'flv', 'wmv', 'm4v', '3gp']
-  },
-  audio: {
-    input: ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'wma', 'opus'],
-    output: ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'wma', 'opus']
-  },
-  image: {
-    input: ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'tiff', 'webp', 'svg'],
-    output: ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'tiff', 'webp']
-  }
-};
 
-// 파일 타입 감지
-function detectFileType(filename: string): 'video' | 'audio' | 'image' | null {
-  const ext = path.extname(filename).toLowerCase().slice(1);
-  
-  if (SUPPORTED_FORMATS.video.input.includes(ext) || SUPPORTED_FORMATS.video.output.includes(ext)) {
-    return 'video';
-  } else if (SUPPORTED_FORMATS.audio.input.includes(ext) || SUPPORTED_FORMATS.audio.output.includes(ext)) {
-    return 'audio';
-  } else if (SUPPORTED_FORMATS.image.input.includes(ext) || SUPPORTED_FORMATS.image.output.includes(ext)) {
-    return 'image';
-  }
-  
-  return null;
-}
 
 // FFmpeg 의존성 확인 (서버리스 환경에서는 항상 사용 가능)
 function checkFFmpeg(): string {
@@ -699,18 +671,3 @@ export async function convertFile(options: ConvertOptions): Promise<{ output: st
 }
 
 // 지원하는 변환 조합 확인
-export function isConversionSupported(inputFormat: string, outputFormat: string): boolean {
-  const inputType = detectFileType(`file.${inputFormat}`);
-  const outputType = detectFileType(`file.${outputFormat}`);
-  
-  if (!inputType || !outputType) return false;
-  
-  // 같은 타입 내에서의 변환은 항상 지원
-  if (inputType === outputType) return true;
-  
-  // 특별한 경우들
-  if (inputType === 'video' && outputType === 'image') return true; // 비디오에서 이미지 추출
-  if (inputType === 'video' && outputType === 'audio') return true; // 비디오에서 오디오 추출
-  
-  return false;
-} 

--- a/next-converter/src/lib/utils/fileFormats.ts
+++ b/next-converter/src/lib/utils/fileFormats.ts
@@ -1,0 +1,33 @@
+export const SUPPORTED_FORMATS = {
+  video: {
+    input: ['mp4', 'avi', 'mov', 'mkv', 'webm', 'flv', 'wmv', 'm4v', '3gp'],
+    output: ['mp4', 'avi', 'mov', 'mkv', 'webm', 'gif', 'flv', 'wmv', 'm4v', '3gp'],
+  },
+  audio: {
+    input: ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'wma', 'opus'],
+    output: ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'wma', 'opus'],
+  },
+  image: {
+    input: ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'tiff', 'webp', 'svg'],
+    output: ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'tiff', 'webp'],
+  },
+};
+
+export type FileCategory = 'video' | 'audio' | 'image' | null;
+
+export function detectFileType(nameOrExt: string): FileCategory {
+  const ext = nameOrExt.includes('.') ? nameOrExt.split('.').pop()?.toLowerCase() : nameOrExt.toLowerCase();
+  if (!ext) return null;
+  if (SUPPORTED_FORMATS.video.input.includes(ext) || SUPPORTED_FORMATS.video.output.includes(ext)) return 'video';
+  if (SUPPORTED_FORMATS.audio.input.includes(ext) || SUPPORTED_FORMATS.audio.output.includes(ext)) return 'audio';
+  if (SUPPORTED_FORMATS.image.input.includes(ext) || SUPPORTED_FORMATS.image.output.includes(ext)) return 'image';
+  return null;
+}
+
+export function isConversionSupported(input: string, output: string): boolean {
+  const inputType = detectFileType(input);
+  const outputType = detectFileType(output);
+  if (!inputType || !outputType) return false;
+  if (inputType === outputType) return true;
+  return inputType === 'video' && (outputType === 'audio' || outputType === 'image');
+}


### PR DESCRIPTION
## Summary
- `detectFileType`와 변환 지원 여부 로직을 `fileFormats` 유틸로 분리
- 기존 파일에서 중복된 상수와 함수 제거
- 새 유틸을 사용하도록 API 라우트 및 컴포넌트 수정

## Testing
- `npm run lint`
- `npm test` *(실패: jest 환경 모듈 부재)*
- `npm run build`
- `npm start` *(로그 확인 불가)*

------
https://chatgpt.com/codex/tasks/task_e_686214deded4832aa7a9b273a426c20b