### PR TITLE
refactor: useAuth 및 useFFmpeg hook 적용

### DIFF
--- a/next-converter/src/app/page.tsx
+++ b/next-converter/src/app/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 import { useEffect } from 'react';
-import { useSession } from 'next-auth/react';
+import { useAuth } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
 import Loading from '@/components/Loading';
 import LoginCard from '@/components/LoginCard';
 import { loginWithGoogle } from '@/lib/utils';
 
 export default function Home() {
-  const { data: session, status } = useSession();
+  const { session, status } = useAuth();
   const router = useRouter();
 
   useEffect(() => {

--- a/next-converter/src/components/Header.tsx
+++ b/next-converter/src/components/Header.tsx
@@ -1,12 +1,13 @@
 'use client';
-import { useSession, signOut } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
+import { useAuth } from '@/lib/auth';
 
 interface HeaderProps {
   subtitle: string;
 }
 
 export default function Header({ subtitle }: HeaderProps) {
-  const { data: session } = useSession();
+  const { session } = useAuth();
   return (
     <>
       <div className="header">

--- a/next-converter/src/lib/hooks/useFFmpeg.ts
+++ b/next-converter/src/lib/hooks/useFFmpeg.ts
@@ -1,0 +1,19 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { initFFmpeg } from '@/lib/ffmpegWasm';
+
+export default function useFFmpeg() {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    initFFmpeg()
+      .then(() => setIsReady(true))
+      .catch((err) => {
+        console.error('FFmpeg 초기화 실패:', err);
+        setError('FFmpeg 로드에 실패했습니다.');
+      });
+  }, []);
+
+  return { isReady, error };
+}


### PR DESCRIPTION
## 요약
- FFmpeg 초기화 로직을 `useFFmpeg` 훅으로 분리
- 인증 정보 접근을 `useAuth` 훅으로 통일
- 관련 컴포넌트와 페이지에서 새 훅 사용

## 테스트
- `npm run lint`
- `npm run build`
- `npm start`
- `npm install`, `npm test`는 네트워크 제한으로 실패

------
https://chatgpt.com/codex/tasks/task_e_686221628a0c832abd3e4b6a53c43af0