### PR TITLE
Add preview placeholder for PDF conversion

### DIFF
--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -9,6 +9,7 @@ import { getAvailableOutputFormats } from '@/lib/utils/conversionHelper';
 
 import LoginCard from '@/components/LoginCard';
 import PdfConverter from '@/components/PdfConverter';
+import ResultPlaceholder from '@/components/ResultPlaceholder';
 import Header from '@/components/Header';
 import ErrorMessage from '@/components/ErrorMessage';
 import { convertFileWithWasm } from '@/lib/ffmpegWasm';
@@ -523,138 +524,100 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
 
       {/* 변환 중일 때 결과 영역 미리 확보 */}
       {isConverting && (
-        <div className="result-placeholder">
-          <div className="placeholder-content">
-            <div className="placeholder-icon">⏳</div>
-            <h2>변환 결과 준비 중...</h2>
-            <p>변환이 완료되면 여기에 결과가 표시됩니다</p>
-            <div className="placeholder-info">
-              <div className="placeholder-item">
-                <span className="placeholder-label">출력 형식:</span>
-                <span className="placeholder-value">{outputFormat.toUpperCase()}</span>
-              </div>
-              <div className="placeholder-item">
-                <span className="placeholder-label">예상 크기:</span>
-                <span className="placeholder-value">
-                  {getEstimatedFileSize(
-                    file!.size,
-                    fileType,
-                    outputFormat,
-                    playbackSpeed,
-                    resolution,
-                    fps,
-                    bitrate,
-                    videoQuality,
-                    audioQuality,
-                    imageQuality
-                  )}
-                </span>
-              </div>
-              <div className="placeholder-item">
-                <span className="placeholder-label">예상 시간:</span>
-                <span className="placeholder-value">
-                  {getEstimatedTime(
-                    file!.size,
-                    fileType,
-                    outputFormat,
-                    playbackSpeed,
-                    resolution,
-                    fps,
-                    videoQuality,
-                    audioQuality
-                  )}
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ResultPlaceholder
+          icon="⏳"
+          title="변환 결과 준비 중..."
+          message="변환이 완료되면 여기에 결과가 표시됩니다"
+          info={[
+            { label: '출력 형식', value: outputFormat.toUpperCase() },
+            {
+              label: '예상 크기',
+              value: getEstimatedFileSize(
+                file!.size,
+                fileType,
+                outputFormat,
+                playbackSpeed,
+                resolution,
+                fps,
+                bitrate,
+                videoQuality,
+                audioQuality,
+                imageQuality,
+              ),
+            },
+            {
+              label: '예상 시간',
+              value: getEstimatedTime(
+                file!.size,
+                fileType,
+                outputFormat,
+                playbackSpeed,
+                resolution,
+                fps,
+                videoQuality,
+                audioQuality,
+              ),
+            },
+          ]}
+        />
       )}
 
       {/* 파일 업로드 및 출력 형식 선택 완료 시 결과 영역 미리 확보 */}
       {file && outputFormat && !isConverting && !result && !error && (
-        <div className="result-placeholder ready">
-          <div className="placeholder-content">
-            <div className="placeholder-icon">📁</div>
-            <h2>변환 준비 완료</h2>
-            <p>변환 버튼을 클릭하면 여기에 결과가 표시됩니다</p>
-            <div className="placeholder-info">
-              <div className="placeholder-item">
-                <span className="placeholder-label">입력 파일:</span>
-                <span className="placeholder-value">{file.name}</span>
-              </div>
-              <div className="placeholder-item">
-                <span className="placeholder-label">출력 형식:</span>
-                <span className="placeholder-value">{outputFormat.toUpperCase()}</span>
-              </div>
-              <div className="placeholder-item">
-                <span className="placeholder-label">파일 크기:</span>
-                <span className="placeholder-value">{(file.size / 1024 / 1024).toFixed(2)} MB</span>
-              </div>
-              <div className="placeholder-item">
-                <span className="placeholder-label">예상 크기:</span>
-                <span className="placeholder-value">
-                  {getEstimatedFileSize(
-                    file.size,
-                    fileType,
-                    outputFormat,
-                    playbackSpeed,
-                    resolution,
-                    fps,
-                    bitrate,
-                    videoQuality,
-                    audioQuality,
-                    imageQuality
-                  )}
-                </span>
-              </div>
-              {fileType === 'video' && outputFormat === 'gif' && (
-                <div className="placeholder-item">
-                  <span className="placeholder-label">재생속도:</span>
-                  <span className="placeholder-value">{playbackSpeed}x</span>
-                </div>
-              )}
-              {fileType === 'video' && resolution !== 'original' && (
-                <div className="placeholder-item">
-                  <span className="placeholder-label">해상도:</span>
-                  <span className="placeholder-value">{resolution}</span>
-                </div>
-              )}
-              {fileType === 'video' && fps !== 10 && (
-                <div className="placeholder-item">
-                  <span className="placeholder-label">프레임레이트:</span>
-                  <span className="placeholder-value">{fps} FPS</span>
-                </div>
-              )}
-              {fileType === 'video' && bitrate && outputFormat !== 'gif' && (
-                <div className="placeholder-item">
-                  <span className="placeholder-label">비트레이트:</span>
-                  <span className="placeholder-value">{bitrate}</span>
-                </div>
-              )}
-              {fileType === 'video' && videoQuality !== '보통' && (
-                <div className="placeholder-item">
-                  <span className="placeholder-label">품질:</span>
-                  <span className="placeholder-value">{videoQuality}</span>
-                </div>
-              )}
-              <div className="placeholder-item">
-                <span className="placeholder-label">예상 시간:</span>
-                <span className="placeholder-value">
-                  {getEstimatedTime(
-                    file.size,
-                    fileType,
-                    outputFormat,
-                    playbackSpeed,
-                    resolution,
-                    fps,
-                    videoQuality,
-                    audioQuality
-                  )}
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ResultPlaceholder
+          ready
+          icon="📁"
+          title="변환 준비 완료"
+          message="변환 버튼을 클릭하면 여기에 결과가 표시됩니다"
+          info={[
+            { label: '입력 파일', value: file.name },
+            { label: '출력 형식', value: outputFormat.toUpperCase() },
+            { label: '파일 크기', value: `${(file.size / 1024 / 1024).toFixed(2)} MB` },
+            {
+              label: '예상 크기',
+              value: getEstimatedFileSize(
+                file.size,
+                fileType,
+                outputFormat,
+                playbackSpeed,
+                resolution,
+                fps,
+                bitrate,
+                videoQuality,
+                audioQuality,
+                imageQuality,
+              ),
+            },
+            ...(fileType === 'video' && outputFormat === 'gif'
+              ? [{ label: '재생속도', value: `${playbackSpeed}x` }]
+              : []),
+            ...(fileType === 'video' && resolution !== 'original'
+              ? [{ label: '해상도', value: resolution }]
+              : []),
+            ...(fileType === 'video' && fps !== 10
+              ? [{ label: '프레임레이트', value: `${fps} FPS` }]
+              : []),
+            ...(fileType === 'video' && bitrate && outputFormat !== 'gif'
+              ? [{ label: '비트레이트', value: bitrate }]
+              : []),
+            ...(fileType === 'video' && videoQuality !== '보통'
+              ? [{ label: '품질', value: videoQuality }]
+              : []),
+            {
+              label: '예상 시간',
+              value: getEstimatedTime(
+                file.size,
+                fileType,
+                outputFormat,
+                playbackSpeed,
+                resolution,
+                fps,
+                videoQuality,
+                audioQuality,
+              ),
+            },
+          ]}
+        />
       )}
 
       {/* GIF에서 WebP 변환 시 특별 안내 */}

--- a/next-converter/src/components/PdfConverter.tsx
+++ b/next-converter/src/components/PdfConverter.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import Header from '@/components/Header';
 import { downloadBlob } from '@/lib/utils';
 import ErrorMessage from '@/components/ErrorMessage';
+import ResultPlaceholder from '@/components/ResultPlaceholder';
+import usePdfEstimates from '@/lib/hooks/usePdfEstimates';
 
 export default function PdfConverter() {
   const [operation, setOperation] = useState<'images' | 'merge' | 'split'>('images');
@@ -11,6 +13,12 @@ export default function PdfConverter() {
   const [result, setResult] = useState<Blob | null>(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const { getEstimatedFileSize, getEstimatedTime } = usePdfEstimates();
+  const operationLabel = {
+    images: '이미지 → PDF 변환',
+    merge: 'PDF 병합',
+    split: 'PDF 페이지 분할',
+  }[operation];
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFiles(e.target.files);
@@ -110,6 +118,37 @@ export default function PdfConverter() {
           {loading ? '처리 중...' : '실행'}
         </button>
       </form>
+
+      {loading && (
+        <ResultPlaceholder
+          icon="⏳"
+          title="변환 결과 준비 중..."
+          message="변환이 완료되면 여기에 결과가 표시됩니다"
+          info={[
+            { label: '작업', value: operationLabel },
+            { label: '예상 크기', value: getEstimatedFileSize(files, operation) },
+            { label: '예상 시간', value: getEstimatedTime(files) },
+          ]}
+        />
+      )}
+
+      {files && !loading && !result && (
+        <ResultPlaceholder
+          ready
+          icon="📁"
+          title="변환 준비 완료"
+          message="실행 버튼을 클릭하면 여기에 결과가 표시됩니다"
+          info={[
+            files.length === 1
+              ? { label: '입력 파일', value: files[0].name }
+              : { label: '파일 수', value: files.length },
+            { label: '작업', value: operationLabel },
+            ...(operation === 'split' ? [{ label: '페이지', value: page }] : []),
+            { label: '예상 크기', value: getEstimatedFileSize(files, operation) },
+            { label: '예상 시간', value: getEstimatedTime(files) },
+          ]}
+        />
+      )}
     </div>
   );
 }

--- a/next-converter/src/components/ResultPlaceholder.tsx
+++ b/next-converter/src/components/ResultPlaceholder.tsx
@@ -1,0 +1,41 @@
+'use client';
+import React from 'react';
+
+interface InfoItem {
+  label: string;
+  value: React.ReactNode;
+}
+
+interface ResultPlaceholderProps {
+  icon: React.ReactNode;
+  title: string;
+  message: string;
+  info: InfoItem[];
+  ready?: boolean;
+}
+
+export default function ResultPlaceholder({
+  icon,
+  title,
+  message,
+  info,
+  ready = false,
+}: ResultPlaceholderProps) {
+  return (
+    <div className={`result-placeholder${ready ? ' ready' : ''}`}>
+      <div className="placeholder-content">
+        <div className="placeholder-icon">{icon}</div>
+        <h2>{title}</h2>
+        <p>{message}</p>
+        <div className="placeholder-info">
+          {info.map(({ label, value }, i) => (
+            <div key={i} className="placeholder-item">
+              <span className="placeholder-label">{label}</span>
+              <span className="placeholder-value">{value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next-converter/src/lib/hooks/usePdfEstimates.ts
+++ b/next-converter/src/lib/hooks/usePdfEstimates.ts
@@ -1,0 +1,26 @@
+'use client';
+
+export default function usePdfEstimates() {
+  const getEstimatedFileSize = (files: FileList | null, operation: string): string => {
+    if (!files || files.length === 0) return '알 수 없음';
+    let total = 0;
+    if (operation === 'split') {
+      total = files[0].size / 2;
+    } else {
+      for (let i = 0; i < files.length; i += 1) {
+        total += files[i].size;
+      }
+      total *= 1.1; // overhead
+    }
+    const mb = total / (1024 * 1024);
+    return mb < 1 ? `${(mb * 1024).toFixed(1)} KB` : `${mb.toFixed(1)} MB`;
+  };
+
+  const getEstimatedTime = (files: FileList | null): string => {
+    if (!files || files.length === 0) return '알 수 없음';
+    const seconds = files.length * 2 + 3;
+    return seconds < 60 ? `${seconds}초` : `${Math.ceil(seconds / 60)}분`;
+  };
+
+  return { getEstimatedFileSize, getEstimatedTime };
+}


### PR DESCRIPTION
## Summary
- pdf 변환에 예상 결과 미리보기 표시 추가
- 미디어 변환에서 사용하던 미리보기 UI를 재사용하도록 ResultPlaceholder 컴포넌트 도입
- Converter와 PdfConverter에서 ResultPlaceholder 활용
- PDF 변환용 예상 크기/시간 계산 훅 추가

## Testing
- `npm run lint`
- `npm test` *(실패: jest-environment-jsdom 미설치)*
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686241522820832aad8d0f03ce488b3b