### PR TITLE
Apply React memoization

### DIFF
--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -1,11 +1,11 @@
 'use client';
-
+import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { FaImage, FaFilePdf } from 'react-icons/fa';
 
 
-export default function BottomNav() {
+const BottomNav = React.memo(function BottomNav() {
   const pathname = usePathname();
 
 
@@ -42,4 +42,6 @@ export default function BottomNav() {
       </ul>
     </nav>
   );
-}
+});
+
+export default BottomNav;

--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { useAuth } from '@/lib/auth';
 import Loading from '@/components/Loading';
 import { loginWithGoogle, downloadBlob } from '@/lib/utils';
@@ -232,6 +232,120 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
       newSpeed < 1 ? '#28a745' : newSpeed > 1 ? '#dc3545' : 'var(--primary-color)'
     );
   };
+
+  const convertingInfo = useMemo(() => {
+    if (!file) return [] as { label: string; value: React.ReactNode }[];
+    return [
+      { label: '출력 형식', value: outputFormat.toUpperCase() },
+      {
+        label: '예상 크기',
+        value: getEstimatedFileSize(
+          file.size,
+          fileType,
+          outputFormat,
+          playbackSpeed,
+          resolution,
+          fps,
+          bitrate,
+          videoQuality,
+          audioQuality,
+          imageQuality,
+        ),
+      },
+      {
+        label: '예상 시간',
+        value: getEstimatedTime(
+          file.size,
+          fileType,
+          outputFormat,
+          playbackSpeed,
+          resolution,
+          fps,
+          videoQuality,
+          audioQuality,
+        ),
+      },
+    ];
+  }, [
+    file,
+    fileType,
+    outputFormat,
+    playbackSpeed,
+    resolution,
+    fps,
+    bitrate,
+    videoQuality,
+    audioQuality,
+    imageQuality,
+    getEstimatedFileSize,
+    getEstimatedTime,
+  ]);
+
+  const readyInfo = useMemo(() => {
+    if (!file) return [] as { label: string; value: React.ReactNode }[];
+    const base = [
+      { label: '입력 파일', value: file.name },
+      { label: '출력 형식', value: outputFormat.toUpperCase() },
+      { label: '파일 크기', value: `${(file.size / 1024 / 1024).toFixed(2)} MB` },
+      {
+        label: '예상 크기',
+        value: getEstimatedFileSize(
+          file.size,
+          fileType,
+          outputFormat,
+          playbackSpeed,
+          resolution,
+          fps,
+          bitrate,
+          videoQuality,
+          audioQuality,
+          imageQuality,
+        ),
+      },
+    ];
+    if (fileType === 'video' && outputFormat === 'gif') {
+      base.push({ label: '재생속도', value: `${playbackSpeed}x` });
+    }
+    if (fileType === 'video' && resolution !== 'original') {
+      base.push({ label: '해상도', value: resolution });
+    }
+    if (fileType === 'video' && fps !== 10) {
+      base.push({ label: '프레임레이트', value: `${fps} FPS` });
+    }
+    if (fileType === 'video' && bitrate && outputFormat !== 'gif') {
+      base.push({ label: '비트레이트', value: bitrate });
+    }
+    if (fileType === 'video' && videoQuality !== '보통') {
+      base.push({ label: '품질', value: videoQuality });
+    }
+    base.push({
+      label: '예상 시간',
+      value: getEstimatedTime(
+        file.size,
+        fileType,
+        outputFormat,
+        playbackSpeed,
+        resolution,
+        fps,
+        videoQuality,
+        audioQuality,
+      ),
+    });
+    return base;
+  }, [
+    file,
+    fileType,
+    outputFormat,
+    playbackSpeed,
+    resolution,
+    fps,
+    bitrate,
+    videoQuality,
+    audioQuality,
+    imageQuality,
+    getEstimatedFileSize,
+    getEstimatedTime,
+  ]);
 
 
   // 로그인 상태 확인
@@ -528,37 +642,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
           icon="⏳"
           title="변환 결과 준비 중..."
           message="변환이 완료되면 여기에 결과가 표시됩니다"
-          info={[
-            { label: '출력 형식', value: outputFormat.toUpperCase() },
-            {
-              label: '예상 크기',
-              value: getEstimatedFileSize(
-                file!.size,
-                fileType,
-                outputFormat,
-                playbackSpeed,
-                resolution,
-                fps,
-                bitrate,
-                videoQuality,
-                audioQuality,
-                imageQuality,
-              ),
-            },
-            {
-              label: '예상 시간',
-              value: getEstimatedTime(
-                file!.size,
-                fileType,
-                outputFormat,
-                playbackSpeed,
-                resolution,
-                fps,
-                videoQuality,
-                audioQuality,
-              ),
-            },
-          ]}
+          info={convertingInfo}
         />
       )}
 
@@ -569,54 +653,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
           icon="📁"
           title="변환 준비 완료"
           message="변환 버튼을 클릭하면 여기에 결과가 표시됩니다"
-          info={[
-            { label: '입력 파일', value: file.name },
-            { label: '출력 형식', value: outputFormat.toUpperCase() },
-            { label: '파일 크기', value: `${(file.size / 1024 / 1024).toFixed(2)} MB` },
-            {
-              label: '예상 크기',
-              value: getEstimatedFileSize(
-                file.size,
-                fileType,
-                outputFormat,
-                playbackSpeed,
-                resolution,
-                fps,
-                bitrate,
-                videoQuality,
-                audioQuality,
-                imageQuality,
-              ),
-            },
-            ...(fileType === 'video' && outputFormat === 'gif'
-              ? [{ label: '재생속도', value: `${playbackSpeed}x` }]
-              : []),
-            ...(fileType === 'video' && resolution !== 'original'
-              ? [{ label: '해상도', value: resolution }]
-              : []),
-            ...(fileType === 'video' && fps !== 10
-              ? [{ label: '프레임레이트', value: `${fps} FPS` }]
-              : []),
-            ...(fileType === 'video' && bitrate && outputFormat !== 'gif'
-              ? [{ label: '비트레이트', value: bitrate }]
-              : []),
-            ...(fileType === 'video' && videoQuality !== '보통'
-              ? [{ label: '품질', value: videoQuality }]
-              : []),
-            {
-              label: '예상 시간',
-              value: getEstimatedTime(
-                file.size,
-                fileType,
-                outputFormat,
-                playbackSpeed,
-                resolution,
-                fps,
-                videoQuality,
-                audioQuality,
-              ),
-            },
-          ]}
+          info={readyInfo}
         />
       )}
 

--- a/next-converter/src/components/ErrorMessage.tsx
+++ b/next-converter/src/components/ErrorMessage.tsx
@@ -1,15 +1,18 @@
 'use client';
+import React from 'react';
 
 interface ErrorMessageProps {
   message: string;
   title?: string;
 }
 
-export default function ErrorMessage({ message, title }: ErrorMessageProps) {
+const ErrorMessage = React.memo(function ErrorMessage({ message, title }: ErrorMessageProps) {
   return (
     <div className="error-message">
       {title && <h3>{title}</h3>}
       <p>{message}</p>
     </div>
   );
-}
+});
+
+export default ErrorMessage;

--- a/next-converter/src/components/Header.tsx
+++ b/next-converter/src/components/Header.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 import { signOut } from 'next-auth/react';
 import { useAuth } from '@/lib/auth';
 
@@ -6,7 +7,7 @@ interface HeaderProps {
   subtitle: string;
 }
 
-export default function Header({ subtitle }: HeaderProps) {
+const Header = React.memo(function Header({ subtitle }: HeaderProps) {
   const { session } = useAuth();
   return (
     <>
@@ -26,4 +27,6 @@ export default function Header({ subtitle }: HeaderProps) {
       <p className="subtitle">{subtitle}</p>
     </>
   );
-}
+});
+
+export default Header;

--- a/next-converter/src/components/LoginCard.tsx
+++ b/next-converter/src/components/LoginCard.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 import Image from 'next/image';
 import { FcGoogle } from 'react-icons/fc';
 
@@ -6,7 +7,7 @@ interface LoginCardProps {
   onLogin: () => void;
 }
 
-export default function LoginCard({ onLogin }: LoginCardProps) {
+const LoginCard = React.memo(function LoginCard({ onLogin }: LoginCardProps) {
   return (
     <div className="flex justify-center">
       <div className="flex min-h-screen min-w-[340px] max-w-[400px] flex-col items-center justify-center bg-gray-100 font-sans">
@@ -48,4 +49,6 @@ export default function LoginCard({ onLogin }: LoginCardProps) {
       </div>
     </div>
   );
-}
+});
+
+export default LoginCard;

--- a/next-converter/src/components/PdfConverter.tsx
+++ b/next-converter/src/components/PdfConverter.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import Header from '@/components/Header';
 import { downloadBlob } from '@/lib/utils';
 import ErrorMessage from '@/components/ErrorMessage';
@@ -61,6 +61,28 @@ export default function PdfConverter() {
     if (!result) return;
     downloadBlob(result, 'result.pdf');
   };
+
+  const loadingInfo = useMemo(() => {
+    return [
+      { label: '작업', value: operationLabel },
+      { label: '예상 크기', value: getEstimatedFileSize(files, operation) },
+      { label: '예상 시간', value: getEstimatedTime(files) },
+    ];
+  }, [operationLabel, files, operation, getEstimatedFileSize, getEstimatedTime]);
+
+  const preparedInfo = useMemo(() => {
+    if (!files) return [] as { label: string; value: React.ReactNode }[];
+    const base = [
+      files.length === 1
+        ? { label: '입력 파일', value: files[0].name }
+        : { label: '파일 수', value: files.length },
+      { label: '작업', value: operationLabel },
+      ...(operation === 'split' ? [{ label: '페이지', value: page }] : []),
+      { label: '예상 크기', value: getEstimatedFileSize(files, operation) },
+      { label: '예상 시간', value: getEstimatedTime(files) },
+    ];
+    return base;
+  }, [files, operation, page, operationLabel, getEstimatedFileSize, getEstimatedTime]);
 
   return (
     <div className="container rounded-[15px]">
@@ -124,11 +146,7 @@ export default function PdfConverter() {
           icon="⏳"
           title="변환 결과 준비 중..."
           message="변환이 완료되면 여기에 결과가 표시됩니다"
-          info={[
-            { label: '작업', value: operationLabel },
-            { label: '예상 크기', value: getEstimatedFileSize(files, operation) },
-            { label: '예상 시간', value: getEstimatedTime(files) },
-          ]}
+          info={loadingInfo}
         />
       )}
 
@@ -138,15 +156,7 @@ export default function PdfConverter() {
           icon="📁"
           title="변환 준비 완료"
           message="실행 버튼을 클릭하면 여기에 결과가 표시됩니다"
-          info={[
-            files.length === 1
-              ? { label: '입력 파일', value: files[0].name }
-              : { label: '파일 수', value: files.length },
-            { label: '작업', value: operationLabel },
-            ...(operation === 'split' ? [{ label: '페이지', value: page }] : []),
-            { label: '예상 크기', value: getEstimatedFileSize(files, operation) },
-            { label: '예상 시간', value: getEstimatedTime(files) },
-          ]}
+          info={preparedInfo}
         />
       )}
     </div>

--- a/next-converter/src/components/ResultPlaceholder.tsx
+++ b/next-converter/src/components/ResultPlaceholder.tsx
@@ -14,7 +14,7 @@ interface ResultPlaceholderProps {
   ready?: boolean;
 }
 
-export default function ResultPlaceholder({
+const ResultPlaceholder = React.memo(function ResultPlaceholder({
   icon,
   title,
   message,
@@ -38,4 +38,6 @@ export default function ResultPlaceholder({
       </div>
     </div>
   );
-}
+});
+
+export default ResultPlaceholder;

--- a/next-converter/src/lib/hooks/usePdfEstimates.ts
+++ b/next-converter/src/lib/hooks/usePdfEstimates.ts
@@ -1,7 +1,8 @@
 'use client';
+import { useCallback } from 'react';
 
 export default function usePdfEstimates() {
-  const getEstimatedFileSize = (files: FileList | null, operation: string): string => {
+  const getEstimatedFileSize = useCallback((files: FileList | null, operation: string): string => {
     if (!files || files.length === 0) return '알 수 없음';
     let total = 0;
     if (operation === 'split') {
@@ -14,13 +15,13 @@ export default function usePdfEstimates() {
     }
     const mb = total / (1024 * 1024);
     return mb < 1 ? `${(mb * 1024).toFixed(1)} KB` : `${mb.toFixed(1)} MB`;
-  };
+  }, []);
 
-  const getEstimatedTime = (files: FileList | null): string => {
+  const getEstimatedTime = useCallback((files: FileList | null): string => {
     if (!files || files.length === 0) return '알 수 없음';
     const seconds = files.length * 2 + 3;
     return seconds < 60 ? `${seconds}초` : `${Math.ceil(seconds / 60)}분`;
-  };
+  }, []);
 
   return { getEstimatedFileSize, getEstimatedTime };
 }


### PR DESCRIPTION
## Summary
- React 컴포넌트에 React.memo 적용
- 자식 컴포넌트로 전달되는 배열 값을 useMemo로 고정
- PDF 예상 계산 훅의 함수들을 useCallback으로 최적화

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(실패: jest-environment-jsdom 누락)*
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686501212afc832a9bcd6089c4c5be38