### PR TITLE
Fix dynamic FFmpeg load

### DIFF
--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -39,7 +39,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
   const [convertedFile, setConvertedFile] = useState<Blob | null>(null);
   const [result, setResult] = useState<ConversionResult | null>(null);
   const [error, setError] = useState('');
-  const { isReady: isFFmpegLoaded, error: ffmpegError } = useFFmpeg();
+  const { isReady: isFFmpegLoaded, error: ffmpegError, loadFFmpeg } = useFFmpeg();
 
   const { getEstimatedTime, getEstimatedFileSize } = useConversionEstimates();
 
@@ -128,9 +128,17 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
 
   // 변환 실행
   const handleConvert = useCallback(async () => {
-    if (!file || !outputFormat || !isFFmpegLoaded) {
+    if (!file || !outputFormat) {
       setError('파일과 출력 형식을 선택해주세요.');
       return;
+    }
+
+    if (!isFFmpegLoaded) {
+      try {
+        await loadFFmpeg();
+      } catch {
+        return;
+      }
     }
 
     setIsConverting(true);
@@ -209,7 +217,8 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
     audioQuality,
     imageResolution,
     imageQuality,
-    isFFmpegLoaded
+    isFFmpegLoaded,
+    loadFFmpeg
   ]);
 
   // 변환된 파일 다운로드

--- a/next-converter/src/lib/ffmpegWasm.ts
+++ b/next-converter/src/lib/ffmpegWasm.ts
@@ -1,4 +1,4 @@
-import { FFmpeg } from '@ffmpeg/ffmpeg';
+import type { FFmpeg } from '@ffmpeg/ffmpeg';
 import { toBlobURL } from '@ffmpeg/util';
 
 
@@ -16,6 +16,7 @@ let ffmpeg: FFmpeg | null = null;
 export async function initFFmpeg(): Promise<FFmpeg> {
   if (ffmpeg) return ffmpeg;
 
+  const { FFmpeg } = await import('@ffmpeg/ffmpeg');
   const ffmpegCdn = process.env.NEXT_PUBLIC_FFMPEG_BASE_URL ?? '/ffmpeg';
 
   // const coreURL = `${ffmpegCdn}/ffmpeg-core.js`;

--- a/next-converter/src/lib/hooks/useFFmpeg.ts
+++ b/next-converter/src/lib/hooks/useFFmpeg.ts
@@ -1,19 +1,21 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import { initFFmpeg } from '@/lib/ffmpegWasm';
 
 export default function useFFmpeg() {
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    initFFmpeg()
-      .then(() => setIsReady(true))
-      .catch((err) => {
-        console.error('FFmpeg 초기화 실패:', err);
-        setError('FFmpeg 로드에 실패했습니다.');
-      });
+  const loadFFmpeg = useCallback(async () => {
+    try {
+      await initFFmpeg();
+      setIsReady(true);
+    } catch (err) {
+      console.error('FFmpeg 초기화 실패:', err);
+      setError('FFmpeg 로드에 실패했습니다.');
+      throw err;
+    }
   }, []);
 
-  return { isReady, error };
+  return { isReady, error, loadFFmpeg };
 }


### PR DESCRIPTION
## Summary
- FFmpeg 모듈을 동적 로드하도록 변경
- FFmpeg 초기화를 사용자가 변환을 실행할 때 수행
- 변환 버튼 클릭 시 초기화 실행

## Testing
- `npm run lint`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68664b1fd644832ab108b787450db46d