### PR TITLE
Fix GIF maker for mixed image types

### DIFF
--- a/next-converter/src/components/GifMaker.tsx
+++ b/next-converter/src/components/GifMaker.tsx
@@ -36,10 +36,13 @@ export default function GifMaker() {
     }
     setLoading(true);
     try {
-      const buffers = await Promise.all(
-        Array.from(files).map((f) => f.arrayBuffer())
+      const inputs = await Promise.all(
+        Array.from(files).map(async (f) => ({
+          buffer: await f.arrayBuffer(),
+          ext: f.name.split('.').pop()?.toLowerCase() || 'png',
+        }))
       );
-      const { data } = await imagesToGifWithWasm(buffers, fps);
+      const { data } = await imagesToGifWithWasm(inputs, fps);
       setResult(new Blob([data], { type: 'image/gif' }));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'GIF 생성 실패');

--- a/next-converter/src/lib/__tests__/imagesToGifWithWasm.test.ts
+++ b/next-converter/src/lib/__tests__/imagesToGifWithWasm.test.ts
@@ -43,7 +43,10 @@ afterAll(() => {
 });
 
 test('GIF frame count matches input image count', async () => {
-  const buffers = [redDot, redDot, redDot].map(toArrayBuffer);
-  const result = await imagesToGifWithWasm(buffers, 5);
-  expect(countGifFrames(result.data)).toBe(buffers.length);
+  const inputs = [redDot, redDot, redDot].map((buf) => ({
+    buffer: toArrayBuffer(buf),
+    ext: 'png',
+  }));
+  const result = await imagesToGifWithWasm(inputs, 5);
+  expect(countGifFrames(result.data)).toBe(inputs.length);
 });


### PR DESCRIPTION
## Summary
- 여러 확장자의 이미지를 GIF로 합칠 때 동작하도록 수정
- GIFMaker 컴포넌트에 파일 확장자 전달 로직 추가
- 테스트 코드 업데이트

## Testing
- `npm run lint`
- `npm test` *(실패: jest-environment-jsdom 모듈 미설치)*
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68692e228720832a8dfa52257f96d490