### PR TITLE
Add preset quality mapping

### DIFF
--- a/next-converter/jest.setup.js
+++ b/next-converter/jest.setup.js
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect';
+require('@testing-library/jest-dom');

--- a/next-converter/src/lib/__tests__/imagesToGifWithWasm.test.ts
+++ b/next-converter/src/lib/__tests__/imagesToGifWithWasm.test.ts
@@ -8,7 +8,7 @@ const redWebp = Buffer.from(
 );
 
 function toArrayBuffer(buf: Buffer): ArrayBuffer {
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
 }
 
 function countGifFrames(buf: Uint8Array): number {
@@ -28,7 +28,12 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_FFMPEG_BASE_URL = `file://${ffmpegPath}`;
   originalFetch = global.fetch;
   global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === 'string' ? input : input.url;
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof Request
+        ? input.url
+        : (input as URL).href;
     if (url.startsWith('file://')) {
       const filePath = url.slice('file://'.length);
       const data = await fs.readFile(filePath);

--- a/next-converter/src/lib/ffmpegWasm.ts
+++ b/next-converter/src/lib/ffmpegWasm.ts
@@ -78,6 +78,12 @@ export async function convertFileWithWasm(
     if (options.quality) {
       const qualityMap = { '낮음': 28, '보통': 23, '높음': 18 };
       args.push('-crf', String(qualityMap[options.quality] || 23));
+      const presetMap: Record<'낮음' | '보통' | '높음', string> = {
+        낮음: 'veryslow',
+        보통: 'slow',
+        높음: 'medium',
+      };
+      args.push('-preset', presetMap[options.quality]);
     }
 
     // 재생속도 설정

--- a/next-converter/src/lib/universalConverter.ts
+++ b/next-converter/src/lib/universalConverter.ts
@@ -186,7 +186,13 @@ function convertVideo(
   // 최적화 옵션 (코덱별로 다르게 적용)
   switch (selectedVideoCodec) {
     case 'libx264':
-      args.push('-preset', 'ultrafast');
+      const presetMap: Record<'낮음' | '보통' | '높음', string> = {
+        낮음: 'veryslow',
+        보통: 'slow',
+        높음: 'medium',
+      };
+      const preset = quality ? presetMap[quality] : 'ultrafast';
+      args.push('-preset', preset);
       args.push('-tune', 'fastdecode');
       args.push('-movflags', '+faststart');
       break;


### PR DESCRIPTION
## 요약
- 품질 옵션에 따라 preset을 결정하도록 universalConverter 수정
- WASM 변환 로직에도 동일한 preset 매핑 적용
- 테스트 설정 및 유틸 수정으로 타입 오류 해결

## 테스트
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(실패)*
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6869e8b56da4832a87189dceb39675f4