### PR TITLE
fix: iOS Safari 다운로드 문제 해결

### DIFF
--- a/next-converter/src/lib/utils.ts
+++ b/next-converter/src/lib/utils.ts
@@ -7,6 +7,19 @@ export function loginWithGoogle() {
 
 export function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
+  const userAgent = navigator.userAgent;
+  const isIos = /iPad|iPhone|iPod/.test(userAgent);
+  const isSafari = /Safari/.test(userAgent) && !/Chrome|CriOS|FxiOS/.test(userAgent);
+  const isIosSafari = isIos && isSafari;
+
+  if (isIosSafari) {
+    window.open(url, '_blank');
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 1000);
+    return;
+  }
+
   const a = document.createElement('a');
   a.href = url;
   a.download = filename;


### PR DESCRIPTION
## 요약
- iOS Safari 환경을 감지해 Blob 다운로드 방식을 수정했습니다.
- 사파리(iOS)에서는 `<a download>` 대신 새 탭을 열어 Blob을 표시하며 `URL.revokeObjectURL` 호출을 지연합니다.
- 그 외 플랫폼에서는 기존 동작을 유지합니다.

## 테스트
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bee51dc9c832a9b615b253f20815b