### PR TITLE
Add preview and open in new tab to GIF maker

### DIFF
--- a/next-converter/src/app/globals.css
+++ b/next-converter/src/app/globals.css
@@ -507,6 +507,12 @@ button[type='submit']:disabled {
   margin-bottom: 20px;
 }
 
+.result-preview {
+  max-width: 100%;
+  display: block;
+  margin: 10px auto;
+}
+
 .resultInfo p {
   margin: 8px 0;
   color: var(--foreground);
@@ -527,10 +533,31 @@ button[type='submit']:disabled {
   display: inline-block;
 }
 
+.open-btn {
+  background: var(--primary-color);
+  color: white;
+  padding: 12px 25px;
+  border: none;
+  border-radius: 8px;
+  font-size: 1em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-decoration: none;
+  display: inline-block;
+  margin-right: 8px;
+}
+
 .download-btn:hover {
   background: #218838;
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(40, 167, 69, 0.3);
+}
+
+.open-btn:hover {
+  background: var(--button-primary-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
 }
 
 /* 오류 메시지 스타일 */
@@ -751,6 +778,7 @@ button[type='submit']:disabled {
 
   .option-row select,
   .option-row input,
+  .open-btn,
   .download-btn,
   button[type='submit'] {
     width: 100% !important;


### PR DESCRIPTION
## 요약
- GIF 변환 결과를 Blob URL로 만들어 미리보기 이미지를 표시
- 결과 영역에 '새 탭에서 열기' 버튼 추가
- 컴포넌트 해제 시 Object URL 정리
- 관련 CSS 스타일 및 반응형 규칙 최소 추가

## 테스트
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bef4c5168832aac3faa8513335ac0