### PR TITLE
Add GIF preview component

### DIFF
--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -15,6 +15,7 @@ import ErrorMessage from '@/components/ErrorMessage';
 import { convertFileWithWasm } from '@/lib/ffmpegWasm';
 import useFFmpeg from '@/lib/hooks/useFFmpeg';
 import { detectFileType, isConversionSupported } from '@/lib/utils/fileFormats';
+import PreviewImage from '@/components/PreviewImage';
 
 interface ConversionResult {
   url: string;
@@ -75,6 +76,15 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
       slider.style.setProperty('--slider-color', 'var(--primary-color)');
     }
   }, [outputFormat]);
+
+  // 결과 미리보기 URL 정리
+  useEffect(() => {
+    return () => {
+      if (result?.url) {
+        URL.revokeObjectURL(result.url);
+      }
+    };
+  }, [result]);
 
   // 출력 형식 필터링
   const filterOutputFormats = (inputType: string) => {
@@ -679,6 +689,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
       {result && (
         <div className="result">
           <h2>변환 결과</h2>
+          {result.format === 'gif' && <PreviewImage url={result.url} />}
           <div className="resultInfo">
             <p>
               <strong>변환 완료!</strong>

--- a/next-converter/src/components/GifMaker.tsx
+++ b/next-converter/src/components/GifMaker.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import useFFmpeg from '@/lib/hooks/useFFmpeg';
 import { imagesToGifWithWasm } from '@/lib/ffmpegWasm';
 import { downloadBlob } from '@/lib/utils';
 import Header from '@/components/Header';
 import ResultPlaceholder from '@/components/ResultPlaceholder';
 import ErrorMessage from '@/components/ErrorMessage';
-import Image from 'next/image';
+import PreviewImage from '@/components/PreviewImage';
 
 export default function GifMaker() {
   const [files, setFiles] = useState<FileList | null>(null);
@@ -18,13 +18,6 @@ export default function GifMaker() {
   const [error, setError] = useState('');
   const { isReady, loadFFmpeg, error: ffmpegError } = useFFmpeg();
 
-  useEffect(() => {
-    return () => {
-      if (resultUrl) {
-        URL.revokeObjectURL(resultUrl);
-      }
-    };
-  }, [resultUrl]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFiles(e.target.files);
@@ -148,15 +141,7 @@ export default function GifMaker() {
       {result && (
         <div className="result">
           <h2>미리보기</h2>
-          {resultUrl && (
-            <Image
-              src={resultUrl}
-              alt="미리보기"
-              width={250}
-              height={250}
-              className="result-preview"
-            />
-          )}
+          {resultUrl && <PreviewImage url={resultUrl} />}
           <div className="resultInfo">
             <p>파일 크기: {(result.size / 1024 / 1024).toFixed(2)} MB</p>
           </div>

--- a/next-converter/src/components/PreviewImage.tsx
+++ b/next-converter/src/components/PreviewImage.tsx
@@ -1,0 +1,22 @@
+'use client';
+import Image from 'next/image';
+import { useEffect } from 'react';
+
+interface PreviewImageProps {
+  url: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+export default function PreviewImage({ url, alt = '미리보기', width = 250, height = 250 }: PreviewImageProps) {
+  useEffect(() => {
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [url]);
+
+  return (
+    <Image src={url} alt={alt} width={width} height={height} className="result-preview" />
+  );
+}


### PR DESCRIPTION
## Summary
- GIF 결과 미리보기 컴포넌트 작성
- Converter와 GifMaker에서 미리보기 컴포넌트 사용
- 변환 결과 URL 정리 로직 추가

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bf50ffac4832abf8e6046b263098e