### PR TITLE
Add filename utility

### DIFF
--- a/next-converter/src/components/Converter.tsx
+++ b/next-converter/src/components/Converter.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { useAuth } from '@/lib/auth';
 import Loading from '@/components/Loading';
-import { loginWithGoogle, downloadBlob } from '@/lib/utils';
+import { loginWithGoogle, downloadBlob, makeFilename } from '@/lib/utils';
 import useConversionEstimates from '@/lib/hooks/useConversionEstimates';
 import { getAvailableOutputFormats } from '@/lib/utils/conversionHelper';
 
@@ -202,7 +202,7 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
 
       setResult({
         url: URL.createObjectURL(convertBlob),
-        filename: `converted.${outputFormat}`,
+        filename: makeFilename(file.name, outputFormat),
         size: (convertBlob.size / 1024 / 1024).toFixed(2),
         format: outputFormat,
       });
@@ -235,9 +235,10 @@ export default function Converter({ showModeSelector = true }: ConverterProps) {
   const handleDownload = useCallback(() => {
     if (convertedFile) {
       const format = result?.format || outputFormat;
-      downloadBlob(convertedFile, `converted.${format}`);
+      const name = file ? makeFilename(file.name, format) : `converted.${format}`;
+      downloadBlob(convertedFile, name);
     }
-  }, [convertedFile, result, outputFormat]);
+  }, [convertedFile, result, outputFormat, file]);
 
   // 재생속도 변경
   const handleSpeedChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/next-converter/src/components/GifMaker.tsx
+++ b/next-converter/src/components/GifMaker.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import useFFmpeg from '@/lib/hooks/useFFmpeg';
 import { imagesToGifWithWasm } from '@/lib/ffmpegWasm';
-import { downloadBlob } from '@/lib/utils';
+import { downloadBlob, makeFilename } from '@/lib/utils';
 import Header from '@/components/Header';
 import ResultPlaceholder from '@/components/ResultPlaceholder';
 import ErrorMessage from '@/components/ErrorMessage';
@@ -59,7 +59,11 @@ export default function GifMaker() {
   };
 
   const download = () => {
-    if (result) downloadBlob(result.blob, 'result.gif');
+    if (result) {
+      const baseName = files?.[0]?.name || 'result';
+      const name = makeFilename(baseName, 'gif');
+      downloadBlob(result.blob, name);
+    }
   };
 
   const loadingInfo = files

--- a/next-converter/src/components/PdfConverter.tsx
+++ b/next-converter/src/components/PdfConverter.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useState, useMemo } from 'react';
 import Header from '@/components/Header';
-import { downloadBlob } from '@/lib/utils';
+import { downloadBlob, makeFilename } from '@/lib/utils';
 import ErrorMessage from '@/components/ErrorMessage';
 import ResultPlaceholder from '@/components/ResultPlaceholder';
 import usePdfEstimates from '@/lib/hooks/usePdfEstimates';
@@ -59,7 +59,12 @@ export default function PdfConverter() {
 
   const download = () => {
     if (!result) return;
-    downloadBlob(result, 'result.pdf');
+    const baseName = files?.[0]?.name || 'result';
+    const name =
+      operation === 'split'
+        ? makeFilename(`${baseName.replace(/\.[^.]+$/, '')}-page-${page}`, 'pdf')
+        : makeFilename(baseName, 'pdf');
+    downloadBlob(result, name);
   };
 
   const loadingInfo = useMemo(() => {

--- a/next-converter/src/lib/utils.ts
+++ b/next-converter/src/lib/utils.ts
@@ -16,3 +16,12 @@ export function downloadBlob(blob: Blob, filename: string) {
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 }
+
+export function makeFilename(original: string, ext: string): string {
+  const base = original
+    .split(/[/\\]/)
+    .pop()
+    ?.replace(/\.[^.]+$/, '') || 'result';
+  const cleanExt = ext.startsWith('.') ? ext : `.${ext}`;
+  return `${base}${cleanExt}`;
+}


### PR DESCRIPTION
## Summary
- add a utility to generate download filenames from the original name
- apply new filename helper across Converter, GifMaker and PdfConverter

## Testing
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686c6dbedd78832a839d64128655a0fd