### PR TITLE
Modify isImage logic and add GIF test

### DIFF
--- a/next-converter/src/lib/__tests__/imagesToGifWithWasm.test.ts
+++ b/next-converter/src/lib/__tests__/imagesToGifWithWasm.test.ts
@@ -71,3 +71,12 @@ test('GIF palette size reflects quality setting', async () => {
   const result = await imagesToGifWithWasm(inputs, 5, '높음');
   expect(getColorTableSize(result.data)).toBe(128);
 });
+
+test('single image to GIF works', async () => {
+  const inputs = [redWebp].map((buf) => ({
+    buffer: toArrayBuffer(buf),
+    ext: 'webp',
+  }));
+  const result = await imagesToGifWithWasm(inputs, 5);
+  expect(countGifFrames(result.data)).toBe(1);
+});

--- a/next-converter/src/lib/ffmpegWasm.ts
+++ b/next-converter/src/lib/ffmpegWasm.ts
@@ -53,7 +53,8 @@ export async function convertFileWithWasm(
     const ffmpegInstance = await initFFmpeg();
 
     const outputType = detectFileType(outputFormat);
-    const isImage = outputType === 'image';
+    // GIF는 영상 처리를 위해 이미지 범주에서 제외
+    const isImage = outputType === 'image' && outputFormat !== 'gif';
 
     // 입력 파일명 생성
     const inputFileName = `input.${inputFormat}`;


### PR DESCRIPTION
## Summary
- 이미지 변환 시 GIF를 예외 처리하도록 isImage 조건 수정
- 단일 이미지의 GIF 변환을 검증하는 테스트 추가

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686c7ff183bc832ab6e3729c49c14c5e