### PR TITLE
Implement enhanced back exit logic

### DIFF
--- a/next-converter/src/components/BackExitHandler.tsx
+++ b/next-converter/src/components/BackExitHandler.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import useBackExit from '@/lib/hooks/useBackExit';
+import { tabs } from './BottomNav';
 
 export default function BackExitHandler() {
-  useBackExit();
+  useBackExit(tabs.length);
   return null;
 }

--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -4,6 +4,12 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { FaImage, FaFilePdf, FaImages } from 'react-icons/fa';
 
+export const tabs = [
+  { href: '/convert/media', icon: <FaImage size={20} />, label: '확장자 변환' },
+  { href: '/convert/gif', icon: <FaImages size={20} />, label: 'GIF 생성' },
+  { href: '/convert/pdf', icon: <FaFilePdf size={20} />, label: 'PDF 관리' },
+];
+
 
 const BottomNav = React.memo(function BottomNav() {
   const pathname = usePathname();
@@ -13,11 +19,6 @@ const BottomNav = React.memo(function BottomNav() {
     // convert 자체 페이지(예: 리디렉트 대상)일 경우만 숨김
     return null;
   }
-  const tabs = [
-    { href: '/convert/media', icon: <FaImage size={20} />, label: '확장자 변환' },
-    { href: '/convert/gif', icon: <FaImages size={20} />, label: 'GIF 생성' },
-    { href: '/convert/pdf', icon: <FaFilePdf size={20} />, label: 'PDF 관리' },
-  ];
 
   return (
     <nav className="bottom-nav z-10 h-[80px] w-full border-t bg-[var(--background)] shadow-md">

--- a/next-converter/src/lib/__tests__/useBackExit.test.tsx
+++ b/next-converter/src/lib/__tests__/useBackExit.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook, act } from '@testing-library/react';
+import useBackExit from '../hooks/useBackExit';
+
+const firePop = () => {
+  const event = new PopStateEvent('popstate');
+  window.dispatchEvent(event);
+};
+
+describe('useBackExit', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    history.replaceState(null, '', '/');
+    history.pushState(null, '', '/page1');
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('허용 횟수 이하에서는 뒤로가기만 동작', () => {
+    const pushSpy = jest.spyOn(history, 'pushState');
+    const goSpy = jest.spyOn(history, 'go');
+
+    renderHook(() => useBackExit(2));
+    act(() => {
+      firePop();
+    });
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(goSpy).not.toHaveBeenCalled();
+  });
+
+  test('허용 횟수 이후에는 토스트 후 종료', () => {
+    const pushSpy = jest.spyOn(history, 'pushState');
+    const goSpy = jest.spyOn(history, 'go');
+
+    renderHook(() => useBackExit(1));
+    act(() => {
+      firePop();
+    });
+
+    expect(document.body.textContent).toContain('앱을 종료하려면 뒤로가기를 한 번 더 누르세요.');
+    expect(pushSpy).toHaveBeenCalled();
+
+    act(() => {
+      firePop();
+    });
+
+    expect(goSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- BottomNav 탭 배열을 외부에서 사용할 수 있도록 export
- 뒤로가기 종료 로직에 허용 횟수 기능 추가 및 개선
- BackExitHandler에서 탭 수를 전달해 훅 사용
- useBackExit 동작을 검증하는 테스트 추가

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`
- `npm test` *(실패)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68707fd10b3c832a90e5a34b0fb97329