### PR TITLE
feat: integrate react-toastify

### DIFF
--- a/next-converter/package.json
+++ b/next-converter/package.json
@@ -36,7 +36,8 @@
     "pdf-lib": "^1.17.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-toastify": "^9.2.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/next-converter/src/app/layout.tsx
+++ b/next-converter/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/lib/auth';
 import InAppRedirectGuard from '@/components/InAppRedirectGuard';
+import ToastProvider from '@/components/ToastProvider';
 import { Analytics } from '@vercel/analytics/next';
 import BackExitHandler from '@/components/BackExitHandler';
 
@@ -65,6 +66,7 @@ export default function RootLayout({
       <body suppressHydrationWarning={true}>
         <BackExitHandler />
         <InAppRedirectGuard />
+        <ToastProvider />
         <AuthProvider>{children}</AuthProvider>
         <Analytics />
       </body>

--- a/next-converter/src/components/ToastProvider.tsx
+++ b/next-converter/src/components/ToastProvider.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+export default function ToastProvider() {
+  return (
+    <ToastContainer
+      position="bottom-center"
+      autoClose={2000}
+      hideProgressBar
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss={false}
+      draggable={false}
+      pauseOnHover={false}
+    />
+  );
+}

--- a/next-converter/src/lib/__tests__/useBackExit.test.tsx
+++ b/next-converter/src/lib/__tests__/useBackExit.test.tsx
@@ -1,5 +1,10 @@
 import { renderHook, act } from '@testing-library/react';
 import useBackExit from '../hooks/useBackExit';
+import { toast } from 'react-toastify';
+
+jest.mock('react-toastify', () => ({
+  toast: { info: jest.fn(), isActive: jest.fn(() => false) }
+}));
 
 const firePop = () => {
   const event = new PopStateEvent('popstate');
@@ -41,7 +46,7 @@ describe('useBackExit', () => {
       firePop();
     });
 
-    expect(document.body.textContent).toContain('앱을 종료하려면 뒤로가기를 한 번 더 누르세요.');
+    expect(toast.info).toHaveBeenCalledWith('앱을 종료하려면 뒤로가기를 한 번 더 누르세요.');
     expect(pushSpy).toHaveBeenCalled();
 
     act(() => {

--- a/next-converter/src/lib/hooks/useBackExit.ts
+++ b/next-converter/src/lib/hooks/useBackExit.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { toast } from 'react-toastify';
 import { tabs } from '@/components/BottomNav';
 
 /**
@@ -11,38 +12,18 @@ import { tabs } from '@/components/BottomNav';
  * 뒤로 이동시켜 앱을 종료합니다.
  */
 export default function useBackExit(allowCount: number = tabs.length + 1) {
-  const toastVisibleRef = useRef(false);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const toastIdRef = useRef<React.ReactText | null>(null);
   const popCountRef = useRef(0);
 
   useEffect(() => {
     const showToast = () => {
-      if (toastVisibleRef.current) return;
-
-      toastVisibleRef.current = true;
-      const toast = document.createElement('div');
-      toast.textContent = '앱을 종료하려면 뒤로가기를 한 번 더 누르세요.';
-      toast.style.position = 'fixed';
-      toast.style.bottom = '20px';
-      toast.style.left = '50%';
-      toast.style.transform = 'translateX(-50%)';
-      toast.style.background = 'rgba(0,0,0,0.7)';
-      toast.style.color = '#fff';
-      toast.style.padding = '10px 20px';
-      toast.style.borderRadius = '4px';
-      toast.style.zIndex = '9999';
-      document.body.appendChild(toast);
-
-      timeoutRef.current = setTimeout(() => {
-        toast.remove();
-        toastVisibleRef.current = false;
-        timeoutRef.current = null;
-      }, 2000);
+      if (toastIdRef.current && toast.isActive(toastIdRef.current)) return;
+      toastIdRef.current = toast.info('앱을 종료하려면 뒤로가기를 한 번 더 누르세요.');
     };
 
     const handlePopState = () => {
       popCountRef.current += 1;
-      if (toastVisibleRef.current) {
+      if (toastIdRef.current && toast.isActive(toastIdRef.current)) {
         history.go(-history.length);
         return;
       }
@@ -55,10 +36,6 @@ export default function useBackExit(allowCount: number = tabs.length + 1) {
     window.addEventListener('popstate', handlePopState);
     return () => {
       window.removeEventListener('popstate', handlePopState);
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
     };
   }, [allowCount]);
 }


### PR DESCRIPTION
## Summary
- react-toastify 패키지 추가
- ToastProvider 컴포넌트 작성 및 전역 배치
- 뒤로가기 종료 로직에서 toast 사용
- 관련 테스트 업데이트

## Testing
- `npm run lint`
- `npm run build` *(실패: react-toastify 모듈을 찾을 수 없음)*
- `npm start` *(실패: 빌드 결과 없음)*
- `npm test` *(여러 테스트 실패 및 모듈 누락 오류)*

------
https://chatgpt.com/codex/tasks/task_e_687093e84b34832abc6324e30f32e01f