### PR TITLE
모바일 브라우저 뒤로가기 종료 개선

### DIFF
--- a/next-converter/jest.setup.js
+++ b/next-converter/jest.setup.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 require('@testing-library/jest-dom');

--- a/next-converter/src/lib/__tests__/useBackExit.test.tsx
+++ b/next-converter/src/lib/__tests__/useBackExit.test.tsx
@@ -17,11 +17,17 @@ describe('useBackExit', () => {
     history.replaceState(null, '', '/');
     history.pushState(null, '', '/page1');
     document.body.innerHTML = '';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Android',
+      configurable: true,
+    });
   });
 
   afterEach(() => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    const nav = window.navigator as { userAgent?: string };
+    delete nav.userAgent;
   });
 
   test('허용 횟수 이하에서는 뒤로가기만 동작', () => {

--- a/next-converter/src/lib/hooks/useBackExit.ts
+++ b/next-converter/src/lib/hooks/useBackExit.ts
@@ -16,6 +16,9 @@ export default function useBackExit(allowCount: number = tabs.length + 1) {
   const popCountRef = useRef(0);
 
   useEffect(() => {
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+    if (!isMobile) return;
+
     const showToast = () => {
       if (toastIdRef.current && toast.isActive(toastIdRef.current)) return;
       toastIdRef.current = toast.info('앱을 종료하려면 뒤로가기를 한 번 더 누르세요.');


### PR DESCRIPTION
## Summary
- 모바일 환경에서만 뒤로가기 두 번으로 앱 종료 기능을 동작하도록 수정
- 테스트 코드에서도 모바일 UA를 설정하여 동작 검증
- jest 설정 파일에 lint 예외 주석 추가

## Testing
- `npx eslint . --ext .ts,.tsx`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6870ab6ef448832aaa34d2e4b99f40cf