### PR TITLE
Fix bottom safe area padding

### DIFF
--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -21,7 +21,10 @@ const BottomNav = React.memo(function BottomNav() {
   }
 
   return (
-    <nav className="bottom-nav z-10 h-[80px] w-full border-t bg-[var(--background)] shadow-md">
+    <nav
+      className="bottom-nav z-10 w-full border-t bg-[var(--background)] shadow-md"
+      style={{ height: 'calc(80px + env(safe-area-inset-bottom))' }}
+    >
       <ul className="m-0 grid w-full list-none grid-cols-3 p-0">
         {tabs.map(({ href, icon, label }) => {
           const active = pathname === href || (href !== '/convert' && pathname.startsWith(href));

--- a/next-converter/src/components/ToastProvider.tsx
+++ b/next-converter/src/components/ToastProvider.tsx
@@ -13,7 +13,7 @@ export default function ToastProvider() {
       pauseOnFocusLoss={false}
       draggable={false}
       pauseOnHover={false}
-      className="pb-[80px]"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 80px)' }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- 토스트 영역에 안전 구역 패딩 적용
- 하단 네비게이션 높이에 안전 구역을 반영하여 일관된 여백 유지

## Testing
- `npm run lint`
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_6873abe8ad58832ab62b4ff56dd6cfd0