### PR TITLE
어드민 대시보드 추가 및 Google ID 관리 기능

### DIFF
--- a/next-converter/src/app/admin/page.tsx
+++ b/next-converter/src/app/admin/page.tsx
@@ -1,0 +1,15 @@
+import requireAdmin from '@/lib/requireAdmin';
+import { getAllowedEmails } from '@/lib/allowedEmails';
+import AdminEmailForm from '@/components/AdminEmailForm';
+
+export default async function AdminPage() {
+  await requireAdmin();
+  const emails = await getAllowedEmails();
+
+  return (
+    <div className="container rounded-[15px] p-4">
+      <h1 className="mb-4 text-xl font-bold">Admin 대시보드</h1>
+      <AdminEmailForm initialEmails={emails} />
+    </div>
+  );
+}

--- a/next-converter/src/app/api/admin/allow/route.ts
+++ b/next-converter/src/app/api/admin/allow/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { addAllowedEmail } from '@/lib/allowedEmails';
+import { isAdmin } from '@/lib/admin';
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session || !isAdmin(session.user?.email)) {
+    return NextResponse.json({ error: '권한이 없습니다.' }, { status: 403 });
+  }
+
+  const { email } = await request.json();
+  if (!email || typeof email !== 'string') {
+    return NextResponse.json({ error: '이메일이 필요합니다.' }, { status: 400 });
+  }
+
+  await addAllowedEmail(email.trim());
+  return NextResponse.json({ success: true });
+}

--- a/next-converter/src/app/api/convert/route.ts
+++ b/next-converter/src/app/api/convert/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { convertFileWithWasm } from '@/lib/ffmpegWasm';
 import { SUPPORTED_FORMATS } from '@/lib/utils/fileFormats';
+import { getAllowedEmails } from '@/lib/allowedEmails';
 
 // 비용 제어를 위한 제한 설정 (Vercel 배포용)
 const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4MB (Vercel 제한)
@@ -45,8 +46,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 환경 변수에서 허용된 이메일 목록 추출
-    const allowedEmails: string[] = process.env.ALLOWED_EMAILS?.split(",").map(email => email.trim()) || [];
+    const allowedEmails: string[] = await getAllowedEmails();
 
     // 이메일 마스킹 함수
     function maskEmail(email: string): string {

--- a/next-converter/src/auth.ts
+++ b/next-converter/src/auth.ts
@@ -1,8 +1,6 @@
 import NextAuth from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
-
-// 허용된 사용자 이메일 목록 (환경변수에서 가져옴)
-const ALLOWED_EMAILS = process.env.ALLOWED_EMAILS?.split(",").map(email => email.trim()) || [];
+import { getAllowedEmails } from '@/lib/allowedEmails';
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
@@ -13,18 +11,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   ],
   callbacks: {
     async signIn({ user }) {
-      // 허용된 이메일인지 확인
-      if (ALLOWED_EMAILS.length === 0) {
-        // 허용된 이메일이 설정되지 않은 경우 모든 사용자 허용 (개발용)
+      const allowedEmails = await getAllowedEmails();
+      if (allowedEmails.length === 0) {
         return true;
       }
-      
-      const isAllowed = ALLOWED_EMAILS.includes(user.email!);
+      const isAllowed = allowedEmails.includes(user.email!);
       if (!isAllowed) {
         console.log(`접근 거부: ${user.email}`);
         return false;
       }
-      
       console.log(`접근 허용: ${user.email}`);
       return true;
     },

--- a/next-converter/src/components/AdminEmailForm.tsx
+++ b/next-converter/src/components/AdminEmailForm.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+
+export default function AdminEmailForm({ initialEmails }: { initialEmails: string[] }) {
+  const [emails, setEmails] = useState(initialEmails);
+  const [email, setEmail] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/admin/allow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (res.ok) {
+      setEmails([...emails, email.trim()]);
+      setEmail('');
+      toast.success('추가되었습니다');
+    } else {
+      const data = await res.json().catch(() => ({}));
+      toast.error(data.error || '추가 실패');
+    }
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Google ID"
+          className="flex-1 rounded border border-gray-300 p-2 text-black"
+          required
+        />
+        <button type="submit" className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600">
+          추가
+        </button>
+      </form>
+      <ul className="mt-4 list-disc pl-4">
+        {emails.map((e) => (
+          <li key={e}>{e}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/next-converter/src/components/BottomNav.tsx
+++ b/next-converter/src/components/BottomNav.tsx
@@ -2,28 +2,36 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { FaImage, FaFilePdf, FaImages } from 'react-icons/fa';
+import { FaImage, FaFilePdf, FaImages, FaUserShield } from 'react-icons/fa';
+import { useAuth } from '@/lib/auth';
+import { isAdmin } from '@/lib/admin';
 
 export const tabs = [
   { href: '/convert/media', icon: <FaImage size={20} />, label: '확장자 변환' },
   { href: '/convert/gif', icon: <FaImages size={20} />, label: 'GIF 생성' },
   { href: '/convert/pdf', icon: <FaFilePdf size={20} />, label: 'PDF 관리' },
+  { href: '/admin', icon: <FaUserShield size={20} />, label: 'Admin 대시보드', adminOnly: true },
 ];
 
 
 const BottomNav = React.memo(function BottomNav() {
   const pathname = usePathname();
-
+  const { user } = useAuth();
+  const availableTabs = React.useMemo(
+    () => tabs.filter(tab => !tab.adminOnly || isAdmin(user?.email)),
+    [user]
+  );
 
   if (pathname === '/convert') {
     // convert 자체 페이지(예: 리디렉트 대상)일 경우만 숨김
     return null;
   }
+  const colsClass = availableTabs.length === 4 ? 'grid-cols-4' : 'grid-cols-3';
 
   return (
     <nav className="bottom-nav z-10 h-[80px] w-full border-t bg-[var(--background)] shadow-md">
-      <ul className="m-0 grid w-full list-none grid-cols-3 p-0">
-        {tabs.map(({ href, icon, label }) => {
+      <ul className={`m-0 grid w-full list-none ${colsClass} p-0`}>
+        {availableTabs.map(({ href, icon, label }) => {
           const active = pathname === href || (href !== '/convert' && pathname.startsWith(href));
           return (
             <li key={href} className="m-0 p-0">

--- a/next-converter/src/data/allowedEmails.json
+++ b/next-converter/src/data/allowedEmails.json
@@ -1,0 +1,3 @@
+[
+  "dlwjd164@gmail.com"
+]

--- a/next-converter/src/lib/admin.ts
+++ b/next-converter/src/lib/admin.ts
@@ -1,0 +1,5 @@
+export const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'dlwjd164@gmail.com';
+
+export function isAdmin(email?: string | null): boolean {
+  return email === ADMIN_EMAIL;
+}

--- a/next-converter/src/lib/allowedEmails.ts
+++ b/next-converter/src/lib/allowedEmails.ts
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { ADMIN_EMAIL } from './admin';
+
+const filePath = path.join(process.cwd(), 'src/data/allowedEmails.json');
+
+async function readFileEmails(): Promise<string[]> {
+  try {
+    const data = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(data) as string[];
+  } catch {
+    return [];
+  }
+}
+
+export async function getAllowedEmails(): Promise<string[]> {
+  const envEmails = process.env.ALLOWED_EMAILS?.split(',').map(e => e.trim()).filter(Boolean) ?? [];
+  const fileEmails = await readFileEmails();
+  const set = new Set<string>([...envEmails, ...fileEmails, ADMIN_EMAIL]);
+  return Array.from(set);
+}
+
+export async function addAllowedEmail(email: string): Promise<void> {
+  const fileEmails = await readFileEmails();
+  if (!fileEmails.includes(email)) {
+    fileEmails.push(email);
+    await fs.writeFile(filePath, JSON.stringify(fileEmails, null, 2));
+  }
+}

--- a/next-converter/src/lib/requireAdmin.ts
+++ b/next-converter/src/lib/requireAdmin.ts
@@ -1,0 +1,11 @@
+import { auth } from '@/auth';
+import { redirect } from 'next/navigation';
+import { isAdmin } from './admin';
+
+export default async function requireAdmin() {
+  const session = await auth();
+  if (!session || !isAdmin(session.user?.email)) {
+    redirect('/');
+  }
+  return session;
+}


### PR DESCRIPTION
## 요약
- 하단 네비게이션에 Admin 대시보드 탭 추가
- 어드민 전용 페이지에서 Google ID 추가 가능
- 허용 이메일 목록을 파일로 관리하고 인증 로직 개선

## 테스트
- `npm install --legacy-peer-deps` (실패: 403 Forbidden)
- `npm run lint`
- `npm test` (실패)
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68afde95a5a0832ab9ebcc1d5d3e3876