### PR TITLE
fix: Firebase로 허용 이메일 저장

### DIFF
--- a/next-converter/package.json
+++ b/next-converter/package.json
@@ -31,6 +31,7 @@
     "@vercel/analytics": "^1.5.0",
     "ffmpeg-static": "^5.2.0",
     "formidable": "^3.5.4",
+    "firebase-admin": "^12.0.0",
     "next": "15.3.4",
     "next-auth": "^5.0.0-beta.29",
     "pdf-lib": "^1.17.1",

--- a/next-converter/src/lib/allowedEmails.ts
+++ b/next-converter/src/lib/allowedEmails.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { ADMIN_EMAIL } from './admin';
+import { getDb } from './firebaseAdmin';
 
 const filePath = path.join(process.cwd(), 'src/data/allowedEmails.json');
 
@@ -15,12 +16,24 @@ async function readFileEmails(): Promise<string[]> {
 
 export async function getAllowedEmails(): Promise<string[]> {
   const envEmails = process.env.ALLOWED_EMAILS?.split(',').map(e => e.trim()).filter(Boolean) ?? [];
-  const fileEmails = await readFileEmails();
-  const set = new Set<string>([...envEmails, ...fileEmails, ADMIN_EMAIL]);
+  const db = await getDb();
+  let dbEmails: string[] = [];
+  if (db) {
+    const snapshot = await db.collection('allowedEmails').get();
+    dbEmails = snapshot.docs.map((doc: { id: string }) => doc.id);
+  } else {
+    dbEmails = await readFileEmails();
+  }
+  const set = new Set<string>([...envEmails, ...dbEmails, ADMIN_EMAIL]);
   return Array.from(set);
 }
 
 export async function addAllowedEmail(email: string): Promise<void> {
+  const db = await getDb();
+  if (db) {
+    await db.collection('allowedEmails').doc(email).set({ createdAt: Date.now() });
+    return;
+  }
   const fileEmails = await readFileEmails();
   if (!fileEmails.includes(email)) {
     fileEmails.push(email);

--- a/next-converter/src/lib/firebaseAdmin.ts
+++ b/next-converter/src/lib/firebaseAdmin.ts
@@ -1,0 +1,14 @@
+export function getDb() {
+  try {
+    const app = eval('require')('firebase-admin/app');
+    const firestore = eval('require')('firebase-admin/firestore');
+    if (!app.getApps().length) {
+      const key = process.env.FIREBASE_SERVICE_ACCOUNT_KEY;
+      if (!key) return null;
+      app.initializeApp({ credential: app.cert(JSON.parse(key)) });
+    }
+    return firestore.getFirestore();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 요약
- Firestore 초기화 로직 추가
- 허용 이메일 목록을 Firestore 우선으로 조회하도록 변경
- Firebase 미설정 시 기존 파일 저장 방식 유지

## 테스트
- `npm run lint`
- `npm run build`
- `npm start`
- `npm test` *(실패: Jest 설정 문제 및 ffmpeg WASM 오류)*
- `npm install --legacy-peer-deps` *(실패: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afe8b5bf40832ab4f7293bab70ace8